### PR TITLE
Add homepage notification on release

### DIFF
--- a/.github/workflows/release-notify.yml
+++ b/.github/workflows/release-notify.yml
@@ -1,0 +1,19 @@
+name: Notify Homepage on Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, 'rc') }}
+    steps:
+      - name: Notify homepage to update submodule
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEPAGE_PAT }}
+          repository: AtlassianPS/AtlassianPS.github.io
+          event-type: module-release
+          client-payload: '{"module": "AtlassianPS.Configuration", "version": "${{ github.ref_name }}"}'


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that notifies the AtlassianPS homepage when a stable release tag is pushed.

- Triggers `module-release` event to `AtlassianPS/AtlassianPS.github.io`
- Only fires for stable releases (excludes alpha/beta/rc tags)
- Enables automatic submodule update PRs on the homepage

## Requirements

- `HOMEPAGE_PAT` secret must be configured with access to dispatch events on the homepage repo

Made with [Cursor](https://cursor.com)