### PR TITLE
Migrate AtlassianPS.Configuration to shared standards v0.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/.github/actions/setup-powershell@master
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2
 
       - run: Invoke-Build -Task Lint
         shell: pwsh
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/.github/actions/setup-powershell@master
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2
 
       - run: Invoke-Build -Task Clean, Build
         shell: pwsh
@@ -66,7 +66,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/.github/actions/setup-powershell@master
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2
         with:
           ps-version: "5"
           # Setup is run below in the powershell (PS 5.1) shell instead of pwsh,
@@ -106,7 +106,7 @@ jobs:
           - { os: macos-latest, name: "macOS" }
     steps:
       - uses: actions/checkout@v6
-      - uses: AtlassianPS/.github/actions/setup-powershell@master
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2
 
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: AtlassianPS/.github/actions/setup-powershell@master
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,58 +4,72 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Tag to release (for manual reruns)"
+        required: true
+        type: string
 
 jobs:
   release:
-    name: "Release"
-    runs-on: "ubuntu-latest"
+    name: Release
+    runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
 
-      - name: Download artifact from commit that got tagged
+      - name: Resolve release ref
+        id: release_ref
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            release_tag="${{ inputs.release_tag }}"
+          else
+            release_tag="${{ github.ref_name }}"
+          fi
+
+          release_sha="$(git rev-list -n 1 "$release_tag")"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Download artifact from tagged commit CI run
         uses: dawidd6/action-download-artifact@v21
         with:
           workflow: ci.yml
           workflow_conclusion: success
-          commit: ${{ github.sha }}
+          commit: ${{ steps.release_ref.outputs.release_sha }}
           name: Release
           path: ./Release/
           if_no_artifact_found: fail
 
-      - uses: AtlassianPS/.github/actions/setup-powershell@master
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2
 
-      - run: Invoke-Build -Task Publish -VersionToPublish ${{ github.ref_name }}
-          -PSGalleryAPIKey ${{ secrets.PSGALLERY_API_KEY }}
+      - name: Publish to PowerShell Gallery
         shell: pwsh
+        run: |
+          Import-Module AtlassianPS.Standards -RequiredVersion 0.1.2 -ErrorAction Stop
+          Publish-AtlassianPSModuleRelease -BuildOutputPath ./Release -ModuleName AtlassianPS.Configuration -ApiKey ${{ secrets.PSGALLERY_API_KEY }}
 
-      - name: Cherry pick CHANGELOG.md
-        id: changelog
-        uses: MatteoCampinoti94/changelog-to-release@v1.0.6
-        with:
-          version-name: ${{ github.ref_name }}
-          configuration: ./.github/changelog.configuration.json
-        if: ${{ hashFiles('CHANGELOG.md') != '' }}
+      - name: Package release zip
+        shell: pwsh
+        run: |
+          Import-Module AtlassianPS.Standards -RequiredVersion 0.1.2 -ErrorAction Stop
+          $null = New-AtlassianPSModulePackage -BuildOutputPath ./Release -ModuleName AtlassianPS.Configuration
 
       - name: Create Release and Upload Asset
         uses: softprops/action-gh-release@v3
         with:
-          body: ${{ steps.changelog.outputs.body }}
+          tag_name: ${{ steps.release_ref.outputs.release_tag }}
+          name: ${{ steps.release_ref.outputs.release_tag }}
           files: ./Release/AtlassianPS.Configuration.zip
           fail_on_unmatched_files: true
           draft: false
-          prerelease:
-            ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name,
-            'beta') || contains(github.ref_name, 'rc') }}
+          prerelease: ${{ contains(steps.release_ref.outputs.release_tag, 'alpha') || contains(steps.release_ref.outputs.release_tag, 'beta') || contains(steps.release_ref.outputs.release_tag, 'rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Notify homepage to update submodule
-        if: ${{ !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, 'rc') }}
-        uses: peter-evans/repository-dispatch@v4
-        with:
-          token: ${{ secrets.HOMEPAGE_PAT }}
-          repository: AtlassianPS/AtlassianPS.github.io
-          event-type: module-release
-          client-payload: '{"module": "AtlassianPS.Configuration", "version": "${{ github.ref_name }}"}'

--- a/AtlassianPS.Configuration.build.ps1
+++ b/AtlassianPS.Configuration.build.ps1
@@ -1,4 +1,5 @@
 ﻿#requires -modules InvokeBuild
+#requires -modules @{ ModuleName = 'AtlassianPS.Standards'; ModuleVersion = '0.1.2'; MaximumVersion = '0.1.2' }
 
 [CmdletBinding()]
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingWriteHost', '')]
@@ -36,33 +37,17 @@ Set-StrictMode -Version Latest
 Import-Module "$PSScriptRoot/Tools/BuildTools.psm1" -Force -ErrorAction Stop
 Import-Module Metadata -Force -ErrorAction Stop
 
-Remove-Item -Path env:\BH* -ErrorAction SilentlyContinue
 $ProjectName = 'AtlassianPS.Configuration'
-$env:BHProjectName = $ProjectName
-$env:BHProjectPath = $PSScriptRoot
-$env:BHModulePath = Join-Path $PSScriptRoot $ProjectName
-$env:BHPSModulePath = $env:BHModulePath
-$env:BHPSModuleManifest = Join-Path $env:BHModulePath "$ProjectName.psd1"
-$env:BHBuildOutput = Join-Path $PSScriptRoot 'Release'
-
-if ($env:GITHUB_ACTIONS) {
-    $env:BHBuildSystem = 'GitHub Actions'
-    $env:BHBranchName = if ($env:GITHUB_HEAD_REF) { $env:GITHUB_HEAD_REF } else { $env:GITHUB_REF_NAME }
-    $env:BHCommitHash = $env:GITHUB_SHA
-    $env:BHBuildNumber = $env:GITHUB_RUN_NUMBER
-}
-else {
-    $env:BHBuildSystem = 'Unknown'
-    $env:BHBranchName = git -C $env:BHProjectPath rev-parse --abbrev-ref HEAD 2>$null
-    $env:BHCommitHash = git -C $env:BHProjectPath rev-parse HEAD 2>$null
-    $env:BHBuildNumber = '0'
-}
-$env:BHCommitMessage = (git -C $env:BHProjectPath log -1 --pretty=%B 2>$null) -join "`n"
+$script:BuildInfo = Initialize-AtlassianPSBuildEnvironment `
+    -ProjectName $ProjectName `
+    -ProjectPath $PSScriptRoot `
+    -VersionToPublish $VersionToPublish `
+    -ResetBuildEnvironmentVariables
 
 if ($VersionToPublish) {
     $VersionToPublish = $VersionToPublish.TrimStart('v')
 }
-$builtManifestPath = "$env:BHBuildOutput/$env:BHProjectName/$env:BHProjectName.psd1"
+$builtManifestPath = $script:BuildInfo.BuiltManifestPath
 
 function Clear-ModuleConfigurationCache {
     [CmdletBinding()]

--- a/Tools/build.requirements.psd1
+++ b/Tools/build.requirements.psd1
@@ -2,6 +2,7 @@
     @{ ModuleName = "InvokeBuild"; RequiredVersion = "5.14.23" }
     @{ ModuleName = "Metadata"; RequiredVersion = "1.5.7" }
     @{ ModuleName = "Configuration"; RequiredVersion = "1.3.1" }
+    @{ ModuleName = "AtlassianPS.Standards"; RequiredVersion = "0.1.2" }
     @{ ModuleName = "Pester"; RequiredVersion = "5.7.1" }
     @{ ModuleName = "Microsoft.PowerShell.PlatyPS"; RequiredVersion = "1.0.1" }
     @{ ModuleName = "PSScriptAnalyzer"; RequiredVersion = "1.25.0" }

--- a/Tools/setup.ps1
+++ b/Tools/setup.ps1
@@ -4,38 +4,22 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingWriteHost', '')]
 param()
 
-$psScriptAnalyzerSettingsUri = 'https://raw.githubusercontent.com/AtlassianPS/.github/83e062b260346c4577d3b41974f0f8aafcc5e7e5/standards/PSScriptAnalyzerSettings.psd1'
 $psScriptAnalyzerSettingsPath = Join-Path (Join-Path $PSScriptRoot '..') 'PSScriptAnalyzerSettings.psd1'
 function Sync-PSScriptAnalyzerSetting {
     [CmdletBinding()]
     param()
 
-    Write-Host "Syncing PSScriptAnalyzer settings from AtlassianPS/.github"
+    Write-Host "Syncing PSScriptAnalyzer settings from AtlassianPS.Standards"
 
     try {
-        $invokeWebRequestParams = @{
-            Uri         = $psScriptAnalyzerSettingsUri
-            ErrorAction = 'Stop'
-        }
-
-        if ($PSVersionTable.PSEdition -eq 'Desktop') {
-            $invokeWebRequestParams.UseBasicParsing = $true
-        }
-
-        $response = Invoke-WebRequest @invokeWebRequestParams
-        $settingsContent = $response.Content
-
-        # Persist the pinned settings locally so build/lint always use the exact same config.
-        $settingsWithCrLf = $settingsContent -replace "`r?`n", "`r`n"
-        [System.IO.File]::WriteAllText(
-            $psScriptAnalyzerSettingsPath,
-            $settingsWithCrLf,
-            [System.Text.UTF8Encoding]::new($false)
-        )
-        Write-Host "Pinned PSScriptAnalyzer settings synchronized to '$psScriptAnalyzerSettingsPath'."
+        Import-Module AtlassianPS.Standards -RequiredVersion '0.1.2' -ErrorAction Stop
+        $resolvedSettingsPath = Sync-AtlassianPSScriptAnalyzerSettings `
+            -DestinationPath $psScriptAnalyzerSettingsPath `
+            -ErrorAction Stop
+        Write-Host "PSScriptAnalyzer settings synchronized to '$resolvedSettingsPath'."
     }
     catch {
-        throw "Unable to download pinned PSScriptAnalyzer settings from '$psScriptAnalyzerSettingsUri'. $($_.Exception.Message)"
+        throw "Unable to synchronize PSScriptAnalyzer settings from AtlassianPS.Standards. $($_.Exception.Message)"
     }
 }
 
@@ -51,8 +35,8 @@ if ((Get-Module PowershellGet -ListAvailable)[0].Version -lt [version]"1.6.0") {
     Install-Module PowershellGet -Scope CurrentUser -Force
 }
 
-Sync-PSScriptAnalyzerSetting
-
 Write-Host "Installing Dependencies"
 Import-Module "$PSScriptRoot/BuildTools.psm1" -Force
 Install-Dependency
+
+Sync-PSScriptAnalyzerSetting


### PR DESCRIPTION
Phase 2 migration for AtlassianPS.Configuration onto shared AtlassianPS.Standards resources.

What changed:
- switched CI/release/copilot workflow setup to shared action AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2
- aligned build bootstrap to shared standards helper usage
- pinned standards module references to 0.1.2 in build/setup/release paths

Validation:
- Invoke-Build -Task Lint, Build, Test