### PR TITLE
Integrate homepage notification into release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,3 +73,12 @@ jobs:
           prerelease: ${{ contains(steps.release_ref.outputs.release_tag, 'alpha') || contains(steps.release_ref.outputs.release_tag, 'beta') || contains(steps.release_ref.outputs.release_tag, 'rc') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify homepage to update submodule
+        if: ${{ !contains(steps.release_ref.outputs.release_tag, 'alpha') && !contains(steps.release_ref.outputs.release_tag, 'beta') && !contains(steps.release_ref.outputs.release_tag, 'rc') }}
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.HOMEPAGE_PAT }}
+          repository: AtlassianPS/AtlassianPS.github.io
+          event-type: module-release
+          client-payload: "{\"module\": \"AtlassianPS.Configuration\", \"version\": \"${{ steps.release_ref.outputs.release_tag }}\"}"


### PR DESCRIPTION
## Summary
- add JiraPS-style homepage dispatch to .github/workflows/release.yml
- dispatch only for stable tags (exclude alpha/beta/rc)
- send module/version payload for homepage submodule update automation

## Notes
- supersedes closed PR #10