### PR TITLE
Add AtlassianPS.Configuration AI instruction baseline

### DIFF
--- a/.cursor/rules/atlassianps-configuration.mdc
+++ b/.cursor/rules/atlassianps-configuration.mdc
@@ -16,8 +16,10 @@ If files disagree, `AGENTS.md` wins.
 
 1. Preserve persisted configuration compatibility (`Configuration.psd1`, `Message`, `ServerList`).
 2. Use existing wrappers/helpers (`Save-Configuration`, private `Invoke-WebRequest`, `Import-MqcnAlias` patterns).
-3. Keep changes test-backed in `Tests/`.
-4. Run `Invoke-Build -Task Build, Test` before completion (and `Lint` for full local validation).
+3. During iteration, run targeted tests when possible (for example `Invoke-Pester -Path 'Tests/Functions/Get-Configuration.Unit.Tests.ps1'`).
+4. Keep changes test-backed in `Tests/`.
+5. Run `Invoke-Build -Task Build, Test` before completion (and `Lint` for full local validation).
+6. Instruction-only changes may be skipped by CI path filters; run local validation and report exact command outcomes.
 
 ## Key Paths
 

--- a/.cursor/rules/atlassianps-configuration.mdc
+++ b/.cursor/rules/atlassianps-configuration.mdc
@@ -1,0 +1,28 @@
+---
+description: AtlassianPS.Configuration project-wide development rules (Cursor entry point)
+alwaysApply: true
+---
+
+# Cursor Entry Point
+
+Follow canonical guidance in this order:
+
+- Project rules: [AGENTS.md](../../AGENTS.md)
+- PowerShell rules: [.github/ai-context/powershell-rules.md](../../.github/ai-context/powershell-rules.md)
+
+If files disagree, `AGENTS.md` wins.
+
+## Hard Requirements
+
+1. Preserve persisted configuration compatibility (`Configuration.psd1`, `Message`, `ServerList`).
+2. Use existing wrappers/helpers (`Save-Configuration`, private `Invoke-WebRequest`, `Import-MqcnAlias` patterns).
+3. Keep changes test-backed in `Tests/`.
+4. Run `Invoke-Build -Task Build, Test` before completion (and `Lint` for full local validation).
+
+## Key Paths
+
+- Module code: `AtlassianPS.Configuration/Public/`, `AtlassianPS.Configuration/Private/`
+- Module bootstrap/schema wiring: `AtlassianPS.Configuration/AtlassianPS.Configuration.psm1`
+- Build script: `AtlassianPS.Configuration.build.ps1`
+- Tests: `Tests/**/*.ps1`
+- Help docs: `docs/en-US/commands/*.md`, `docs/en-US/about_*.md`

--- a/.github/ai-context/powershell-rules.md
+++ b/.github/ai-context/powershell-rules.md
@@ -13,10 +13,11 @@ Invoke-Build -Task Build, Test
 Focused iteration command:
 
 ```powershell
-Invoke-Pester -Path 'Tests/Functions/<FunctionName>.Unit.Tests.ps1'
+Invoke-Pester -Path 'Tests/Functions/Get-Configuration.Unit.Tests.ps1'
 ```
 
 Run full `Build, Test` before completion.
+Instruction-only changes may be skipped by CI path filters; run local validation and report exact command outcomes.
 
 ## Source Layout
 

--- a/.github/ai-context/powershell-rules.md
+++ b/.github/ai-context/powershell-rules.md
@@ -1,0 +1,56 @@
+# AtlassianPS.Configuration PowerShell Rules
+
+This file captures practical coding/build/test rules shared across AI entry points.
+
+## Build and Test Commands (run from repo root)
+
+```powershell
+./Tools/setup.ps1
+Invoke-Build -Task Lint
+Invoke-Build -Task Build, Test
+```
+
+Focused iteration command:
+
+```powershell
+Invoke-Pester -Path 'Tests/Functions/<FunctionName>.Unit.Tests.ps1'
+```
+
+Run full `Build, Test` before completion.
+
+## Source Layout
+
+- Public cmdlets: `AtlassianPS.Configuration/Public/*.ps1`
+- Private helpers: `AtlassianPS.Configuration/Private/*.ps1`
+- Module bootstrap/schema wiring: `AtlassianPS.Configuration/AtlassianPS.Configuration.psm1`
+- Persisted defaults: `AtlassianPS.Configuration/Configuration.psd1`
+- Build script: `AtlassianPS.Configuration.build.ps1`
+- Docs/help sources: `docs/en-US/commands/*.md`, `docs/en-US/about_*.md`
+- Tests: `Tests/**/*.ps1`
+
+## Configuration Compatibility Rules
+
+- Keep persisted key semantics backward compatible (`Message`, `ServerList`).
+- Keep `ServerList` entries compatible with `[AtlassianPS.ServerData]`.
+- Preserve metadata converter contracts used by `Import-Configuration` / `Export-Configuration`.
+- Persist updates through `Save-Configuration` (which strips `ServerList[].Session` intentionally).
+- Do not introduce direct ad-hoc writes to user configuration files.
+
+## Wrapper and Helper Rules
+
+- Prefer existing public/private config helpers over duplicate IO logic.
+- Use private `Invoke-WebRequest` wrapper when module HTTP behavior is required.
+- Maintain mockable module-qualified calls with `Import-MqcnAlias` where the pattern already exists.
+- Use `WriteError` / `ThrowError` helpers for consistent error records.
+
+## Coding Conventions
+
+- Follow existing cmdlet and helper patterns.
+- Add comments only for non-obvious constraints or decisions.
+- Use `#ToDo:<Category>` markers for explicit technical debt tracking.
+- Keep changes focused and avoid unrelated refactors.
+
+## Documentation Conventions
+
+- User-facing command documentation belongs in `docs/en-US/commands/*.md`.
+- Include changelog updates for user-visible behavior changes.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,7 @@ Follow canonical guidance in this order:
 
 1. [../AGENTS.md](../AGENTS.md)
 2. [ai-context/powershell-rules.md](ai-context/powershell-rules.md)
+3. [instructions/](instructions/)
 
 If files disagree, `AGENTS.md` wins.
 
@@ -11,8 +12,10 @@ If files disagree, `AGENTS.md` wins.
 
 1. Preserve persisted configuration compatibility (`Configuration.psd1`, `Message`, `ServerList`).
 2. Use existing wrappers/helpers (`Save-Configuration`, private `Invoke-WebRequest`, `Import-MqcnAlias` patterns).
-3. Keep changes test-backed in `Tests/`.
-4. Run `Invoke-Build -Task Build, Test` before completion (and `Lint` for full local validation).
+3. During iteration, run targeted tests when possible (for example `Invoke-Pester -Path 'Tests/Functions/Get-Configuration.Unit.Tests.ps1'`).
+4. Keep changes test-backed in `Tests/`.
+5. Run `Invoke-Build -Task Build, Test` before completion (and `Lint` for full local validation).
+6. Instruction-only changes may be skipped by CI path filters; run local validation and report exact command outcomes.
 
 ## Key Paths
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,23 @@
+# GitHub Copilot Entry Point
+
+Follow canonical guidance in this order:
+
+1. [../AGENTS.md](../AGENTS.md)
+2. [ai-context/powershell-rules.md](ai-context/powershell-rules.md)
+
+If files disagree, `AGENTS.md` wins.
+
+## Hard Requirements
+
+1. Preserve persisted configuration compatibility (`Configuration.psd1`, `Message`, `ServerList`).
+2. Use existing wrappers/helpers (`Save-Configuration`, private `Invoke-WebRequest`, `Import-MqcnAlias` patterns).
+3. Keep changes test-backed in `Tests/`.
+4. Run `Invoke-Build -Task Build, Test` before completion (and `Lint` for full local validation).
+
+## Key Paths
+
+- Module code: `AtlassianPS.Configuration/Public/`, `AtlassianPS.Configuration/Private/`
+- Module bootstrap/schema wiring: `AtlassianPS.Configuration/AtlassianPS.Configuration.psm1`
+- Build script: `AtlassianPS.Configuration.build.ps1`
+- Tests: `Tests/**/*.ps1`
+- Help docs: `docs/en-US/commands/*.md`, `docs/en-US/about_*.md`

--- a/.github/instructions/configuration-compatibility.instructions.md
+++ b/.github/instructions/configuration-compatibility.instructions.md
@@ -1,0 +1,20 @@
+---
+applyTo: "**/*.ps1"
+---
+
+# PowerShell File Rules (GitHub Copilot)
+
+This file applies to all `.ps1` files. It references shared rules.
+
+**Canonical source**: [.github/ai-context/powershell-rules.md](../ai-context/powershell-rules.md)
+
+## Quick Reference
+
+1. **Persisted compatibility** — preserve `Configuration.psd1` key semantics, especially `Message` and `ServerList`.
+2. **Persistence flow** — use `Get-Configuration`, `Set-Configuration`, `Remove-Configuration`, and `Save-Configuration`; avoid ad-hoc config file writes.
+3. **Wrapper usage** — use existing wrappers/helpers (`Save-Configuration`, private `Invoke-WebRequest`, `Import-MqcnAlias` patterns).
+4. **Tests required** — during iteration run targeted `Invoke-Pester` when possible (for example `Invoke-Pester -Path 'Tests/Functions/Get-Configuration.Unit.Tests.ps1'`).
+5. **Final validation** — run `./Tools/setup.ps1`, `Invoke-Build -Task Lint`, and `Invoke-Build -Task Build, Test`.
+6. **CI path filters** — instruction-only changes may be skipped by CI; run local validation and report exact command outcomes.
+
+For full rules, read `.github/ai-context/powershell-rules.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AI Instructions for AtlassianPS.Configuration
+
+> **Canonical AI guidance for this repository.**
+> `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, and `.cursor/rules/*.mdc` must stay aligned with this file.
+
+## Non-Negotiable Rules
+
+1. **Ship complete vertical slices**: code, tests, docs, and changelog updates move together.
+2. **Do not finish on a red build**: run `Invoke-Build -Task Build, Test` at minimum before completion.
+3. **Preserve persisted configuration compatibility**: do not break existing `Configuration.psd1` data.
+4. **Use existing wrappers/helpers**: no ad-hoc config persistence or direct command bypasses.
+5. **Validate behavior changes with tests**: update or add tests under `Tests/`.
+
+## Repository Surfaces
+
+- Module source: `AtlassianPS.Configuration/Public/*.ps1`, `AtlassianPS.Configuration/Private/*.ps1`
+- Module bootstrap and schema wiring: `AtlassianPS.Configuration/AtlassianPS.Configuration.psm1`
+- Persisted defaults: `AtlassianPS.Configuration/Configuration.psd1`
+- Build entrypoint: `AtlassianPS.Configuration.build.ps1`
+- Tests: `Tests/**/*.ps1`
+- Help sources: `docs/en-US/commands/*.md`, `docs/en-US/about_*.md`
+
+## Configuration Schema and Compatibility Requirements
+
+- Keep top-level configuration keys compatible with existing installs, especially `Message` and `ServerList`.
+- Keep `ServerList` entries compatible with `[AtlassianPS.ServerData]` serialization/deserialization.
+- Preserve metadata converter contracts in `AtlassianPS.Configuration.psm1` (`AtlassianPSMessageStyle`, `AtlassianPSServerData`).
+- Persist config only through `Save-Configuration`; it intentionally strips `ServerList[].Session` before export.
+- Do not rename/remove persisted keys or change semantics without migration coverage and regression tests.
+
+## Wrapper and Helper Requirements
+
+- Use `Get-Configuration`, `Set-Configuration`, `Remove-Configuration`, and `Save-Configuration` for config IO flows.
+- Use the module’s private `Invoke-WebRequest` wrapper for HTTP behavior that must stay cross-version compatible.
+- Keep module-qualified command wrappers mockable via `Import-MqcnAlias` when following existing helper patterns.
+- Use existing error helpers (`WriteError`, `ThrowError`) for consistent error records.
+
+## Validation Commands (run from repo root)
+
+```powershell
+./Tools/setup.ps1
+Invoke-Build -Task Lint
+Invoke-Build -Task Build, Test
+```
+
+Recommended focused loop while iterating:
+
+```powershell
+Invoke-Pester -Path 'Tests/Functions/<FunctionName>.Unit.Tests.ps1'
+```
+
+## CI/CD References
+
+- `.github/workflows/ci.yml` is the required quality gate.
+- `.github/workflows/release.yml` publishes tagged releases.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,26 @@
 # AI Instructions for AtlassianPS.Configuration
 
 > **Canonical AI guidance for this repository.**
-> `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, and `.cursor/rules/*.mdc` must stay aligned with this file.
+> `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md`, and `.cursor/rules/*.mdc` must stay aligned with this file.
 
 ## Non-Negotiable Rules
 
 1. **Ship complete vertical slices**: code, tests, docs, and changelog updates move together.
-2. **Do not finish on a red build**: run `Invoke-Build -Task Build, Test` at minimum before completion.
-3. **Preserve persisted configuration compatibility**: do not break existing `Configuration.psd1` data.
-4. **Use existing wrappers/helpers**: no ad-hoc config persistence or direct command bypasses.
-5. **Validate behavior changes with tests**: update or add tests under `Tests/`.
+2. **Use the right test loop**: during iteration, run targeted `Invoke-Pester` for affected tests when possible (for example `Invoke-Pester -Path 'Tests/Functions/Get-Configuration.Unit.Tests.ps1'`).
+3. **Do not finish on a red build**: run `Invoke-Build -Task Build, Test` at minimum before completion.
+4. **Preserve persisted configuration compatibility**: do not break existing `Configuration.psd1` data.
+5. **Use existing wrappers/helpers**: no ad-hoc config persistence or direct command bypasses.
+6. **Validate behavior changes with tests**: update or add tests under `Tests/`.
+
+## AI Tool Compatibility
+
+| Tool | Entry point | Canonical references |
+|------|-------------|----------------------|
+| GitHub Copilot | `.github/copilot-instructions.md` | `AGENTS.md`, `.github/ai-context/powershell-rules.md` |
+| GitHub Copilot (file rules) | `.github/instructions/configuration-compatibility.instructions.md` | `.github/ai-context/powershell-rules.md` |
+| Cursor | `.cursor/rules/atlassianps-configuration.mdc` | `AGENTS.md`, `.github/ai-context/powershell-rules.md` |
+| Claude Code | `CLAUDE.md` | `AGENTS.md`, `.github/ai-context/powershell-rules.md` |
+| Gemini/Antigravity | `GEMINI.md` | `AGENTS.md`, `.github/ai-context/powershell-rules.md` |
 
 ## Repository Surfaces
 
@@ -46,10 +57,11 @@ Invoke-Build -Task Build, Test
 Recommended focused loop while iterating:
 
 ```powershell
-Invoke-Pester -Path 'Tests/Functions/<FunctionName>.Unit.Tests.ps1'
+Invoke-Pester -Path 'Tests/Functions/Get-Configuration.Unit.Tests.ps1'
 ```
 
 ## CI/CD References
 
-- `.github/workflows/ci.yml` is the required quality gate.
+- `.github/workflows/ci.yml` is the required quality gate for runtime/code changes.
+- Instruction-only changes can be skipped by CI path filters; run local validation and report exact command outcomes.
 - `.github/workflows/release.yml` publishes tagged releases.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,10 @@ If files disagree, `AGENTS.md` wins.
 
 1. Preserve persisted configuration compatibility (`Configuration.psd1`, `Message`, `ServerList`).
 2. Use existing wrappers/helpers (`Save-Configuration`, private `Invoke-WebRequest`, `Import-MqcnAlias` patterns).
-3. Keep changes test-backed in `Tests/`.
-4. Run `Invoke-Build -Task Build, Test` before completion (and `Lint` for full local validation).
+3. During iteration, run targeted tests when possible (for example `Invoke-Pester -Path 'Tests/Functions/Get-Configuration.Unit.Tests.ps1'`).
+4. Keep changes test-backed in `Tests/`.
+5. Run `Invoke-Build -Task Build, Test` before completion (and `Lint` for full local validation).
+6. Instruction-only changes may be skipped by CI path filters; run local validation and report exact command outcomes.
 
 ## Key Paths
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# Claude Code Entry Point
+
+Follow canonical guidance in this order:
+
+1. [AGENTS.md](AGENTS.md)
+2. [.github/ai-context/powershell-rules.md](.github/ai-context/powershell-rules.md)
+
+If files disagree, `AGENTS.md` wins.
+
+## Hard Requirements
+
+1. Preserve persisted configuration compatibility (`Configuration.psd1`, `Message`, `ServerList`).
+2. Use existing wrappers/helpers (`Save-Configuration`, private `Invoke-WebRequest`, `Import-MqcnAlias` patterns).
+3. Keep changes test-backed in `Tests/`.
+4. Run `Invoke-Build -Task Build, Test` before completion (and `Lint` for full local validation).
+
+## Key Paths
+
+- Module code: `AtlassianPS.Configuration/Public/`, `AtlassianPS.Configuration/Private/`
+- Module bootstrap/schema wiring: `AtlassianPS.Configuration/AtlassianPS.Configuration.psm1`
+- Build script: `AtlassianPS.Configuration.build.ps1`
+- Tests: `Tests/**/*.ps1`
+- Help docs: `docs/en-US/commands/*.md`, `docs/en-US/about_*.md`

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -11,8 +11,10 @@ If files disagree, `AGENTS.md` wins.
 
 1. Preserve persisted configuration compatibility (`Configuration.psd1`, `Message`, `ServerList`).
 2. Use existing wrappers/helpers (`Save-Configuration`, private `Invoke-WebRequest`, `Import-MqcnAlias` patterns).
-3. Keep changes test-backed in `Tests/`.
-4. Run `Invoke-Build -Task Build, Test` before completion (and `Lint` for full local validation).
+3. During iteration, run targeted tests when possible (for example `Invoke-Pester -Path 'Tests/Functions/Get-Configuration.Unit.Tests.ps1'`).
+4. Keep changes test-backed in `Tests/`.
+5. Run `Invoke-Build -Task Build, Test` before completion (and `Lint` for full local validation).
+6. Instruction-only changes may be skipped by CI path filters; run local validation and report exact command outcomes.
 
 ## Key Paths
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,23 @@
+# Gemini/Antigravity Entry Point
+
+Follow canonical guidance in this order:
+
+1. [AGENTS.md](AGENTS.md)
+2. [.github/ai-context/powershell-rules.md](.github/ai-context/powershell-rules.md)
+
+If files disagree, `AGENTS.md` wins.
+
+## Hard Requirements
+
+1. Preserve persisted configuration compatibility (`Configuration.psd1`, `Message`, `ServerList`).
+2. Use existing wrappers/helpers (`Save-Configuration`, private `Invoke-WebRequest`, `Import-MqcnAlias` patterns).
+3. Keep changes test-backed in `Tests/`.
+4. Run `Invoke-Build -Task Build, Test` before completion (and `Lint` for full local validation).
+
+## Key Paths
+
+- Module code: `AtlassianPS.Configuration/Public/`, `AtlassianPS.Configuration/Private/`
+- Module bootstrap/schema wiring: `AtlassianPS.Configuration/AtlassianPS.Configuration.psm1`
+- Build script: `AtlassianPS.Configuration.build.ps1`
+- Tests: `Tests/**/*.ps1`
+- Help docs: `docs/en-US/commands/*.md`, `docs/en-US/about_*.md`


### PR DESCRIPTION
## Summary
- add canonical AGENTS.md and tool entrypoint instruction files
- add Copilot file-pattern instruction rules at `.github/instructions/configuration-compatibility.instructions.md`
- strengthen test-loop guidance across entrypoints: targeted `Invoke-Pester` during iteration and full `Invoke-Build -Task Build, Test` before finalization
- align CI wording with repository policy: instruction-only changes may be skipped by CI path filters and require explicit local validation reporting
- preserve configuration-specific compatibility guidance for persisted schema keys and wrapper usage

## Validation
- `./Tools/setup.ps1`
- `Invoke-Build -Task Lint`
- `Invoke-Build -Task Build, Test`

## Notes
- This PR updates AI instruction surfaces only and does not change runtime cmdlet behavior.
- `.github/workflows/ci.yml` path filters can skip instruction-only changes; local validation was run and should be reported with command outcomes.