### PR TITLE
Fix configuration release readiness issues

### DIFF
--- a/AtlassianPS.Configuration/Private/Save-Configuration.ps1
+++ b/AtlassianPS.Configuration/Private/Save-Configuration.ps1
@@ -7,10 +7,27 @@
 
         Import-MqcnAlias -Alias "ExportConfiguration" -Command "Configuration\Export-Configuration"
 
-        $export = Get-Configuration -AsHashtable
-        $export["ServerList"] |
-            Where-Object { $_.Session } |
-            Foreach-Object { $_.Session = $null }
+        $configuration = Get-Configuration -AsHashtable
+        $export = @{}
+        foreach ($key in $configuration.Keys) {
+            $export[$key] = $configuration[$key]
+        }
+
+        $serverList = [System.Collections.Generic.List[AtlassianPS.ServerData]]::new()
+        foreach ($server in @($export["ServerList"])) {
+            if (-not $server) { continue }
+
+            $serverData = [AtlassianPS.ServerData]@{
+                Id          = $server.Id
+                Name        = $server.Name
+                Uri         = $server.Uri
+                Type        = $server.Type
+                Certificate = $server.Certificate
+                Headers     = if ($server.Headers) { $server.Headers.Clone() } else { $null }
+            }
+            $serverList.Add($serverData)
+        }
+        $export["ServerList"] = $serverList
 
         ExportConfiguration -InputObject $export 3>$null
 

--- a/AtlassianPS.Configuration/Public/Add-ServerConfiguration.ps1
+++ b/AtlassianPS.Configuration/Public/Add-ServerConfiguration.ps1
@@ -5,6 +5,7 @@
     param(
         [Parameter( Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName )]
         [Alias('Url', 'Address')]
+        [ValidateScript( { $_.IsAbsoluteUri } )]
         [Uri]
         $Uri,
 
@@ -24,19 +25,15 @@
 
         [Parameter( ValueFromPipelineByPropertyName )]
         [Hashtable]
-        $Headers = @{}
+        $Headers
     )
 
     begin {
         Write-Verbose "Function started"
 
-        if (-not ($script:Configuration.ServerList)) {
-            $script:Configuration.ServerList = $null
-        }
-
         $serverList = [System.Collections.Generic.List[AtlassianPS.ServerData]]::new()
-        if (Get-ServerConfiguration) {
-            [System.Collections.Generic.List[AtlassianPS.ServerData]]$serverList = Get-ServerConfiguration
+        foreach ($server in @(Get-ServerConfiguration)) {
+            $serverList.Add($server)
         }
     }
 
@@ -44,34 +41,33 @@
         Write-DebugMessage "ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "PSBoundParameters: $($PSBoundParameters | Out-String)"
 
-        if (-not $Name) {
-            $Name = $Uri.Authority
-        }
+        $entryName = if ($PSBoundParameters.ContainsKey('Name')) { $Name } else { $Uri.Authority }
+        $entryHeaders = if ($PSBoundParameters.ContainsKey('Headers')) { $Headers } else { @{} }
 
-        if (Get-ServerConfiguration | Where-Object Name -eq $Name) {
+        if ($serverList | Where-Object Name -eq $entryName) {
             $writeErrorSplat = @{
                 ExceptionType = "System.ApplicationException"
-                Message       = "An entry with name [$Name] already exists"
+                Message       = "An entry with name [$entryName] already exists"
                 ErrorId       = "AtlassianPS.ServerData.EntryExists"
                 Category      = "InvalidData"
-                TargetObject  = $Name
+                TargetObject  = $entryName
             }
             WriteError @writeErrorSplat
         }
         else {
-            if (-not ($index = ((Get-ServerConfiguration).Id | Measure-Object -Maximum).Maximum)) {
+            if (-not ($index = ($serverList.Id | Measure-Object -Maximum).Maximum)) {
                 $index = 0
             }
             $index++
 
             $config = [AtlassianPS.ServerData]@{
                 Id      = $index
-                Name    = $Name
+                Name    = $entryName
                 Uri     = ([Uri]($Uri.AbsoluteUri -replace "\/$", ""))
                 Type    = $Type
                 # IsCloudServer = (Test-ServerIsCloud -Type $Type -Uri $Uri -Headers $Headers -ErrorAction Stop -verbose)
                 Session = $Session
-                Headers = $Headers
+                Headers = $entryHeaders
             }
 
             Write-Verbose "Adding server #$($index): [$($config.Name)]"

--- a/AtlassianPS.Configuration/Public/Remove-Configuration.ps1
+++ b/AtlassianPS.Configuration/Public/Remove-Configuration.ps1
@@ -22,6 +22,8 @@
 
     begin {
         Write-Verbose "Function started"
+
+        $reservedNames = @('ServerList', 'Message')
     }
 
     process {
@@ -29,6 +31,18 @@
         Write-DebugMessage "PSBoundParameters: $($PSBoundParameters | Out-String)"
 
         foreach ($_name in $Name) {
+            if ($_name -in $reservedNames) {
+                $writeErrorSplat = @{
+                    ExceptionType = "System.ApplicationException"
+                    Message       = "Configuration key [$_name] is reserved and cannot be removed with Remove-Configuration"
+                    ErrorId       = "AtlassianPS.Configuration.ReservedKey"
+                    Category      = "InvalidArgument"
+                    TargetObject  = $_name
+                }
+                WriteError @writeErrorSplat
+                continue
+            }
+
             Write-Verbose "Filtering for [name = $_name]"
 
             $script:Configuration.Remove($_name)

--- a/AtlassianPS.Configuration/Public/Remove-Configuration.ps1
+++ b/AtlassianPS.Configuration/Public/Remove-Configuration.ps1
@@ -23,7 +23,7 @@
     begin {
         Write-Verbose "Function started"
 
-        $reservedNames = @('ServerList', 'Message')
+        $reservedNames = @('ServerList')
     }
 
     process {

--- a/AtlassianPS.Configuration/Public/Remove-ServerConfiguration.ps1
+++ b/AtlassianPS.Configuration/Public/Remove-ServerConfiguration.ps1
@@ -57,13 +57,8 @@
 
     end {
         Write-DebugMessage "Persisting ServerList"
-        $persistedServerList = [System.Collections.Generic.List[AtlassianPS.ServerData]]::new()
-        foreach ($server in $serverList) {
-            $persistedServerList.Add($server)
-        }
-
         $script:Configuration.Remove("ServerList")
-        $script:Configuration.Add("ServerList", $persistedServerList)
+        $script:Configuration.Add("ServerList", $serverList)
         Save-Configuration
 
         Write-Verbose "Function ended"

--- a/AtlassianPS.Configuration/Public/Remove-ServerConfiguration.ps1
+++ b/AtlassianPS.Configuration/Public/Remove-ServerConfiguration.ps1
@@ -14,6 +14,7 @@
             }
         )]
         [Alias('ServerName', 'Alias')]
+        [ValidateNotNullOrEmpty()]
         [String[]]
         $Name
     )
@@ -21,7 +22,10 @@
     begin {
         Write-Verbose "Function started"
 
-        $serverList = Get-ServerConfiguration
+        $serverList = [System.Collections.Generic.List[AtlassianPS.ServerData]]::new()
+        foreach ($server in @(Get-ServerConfiguration)) {
+            $serverList.Add($server)
+        }
     }
 
     process {
@@ -42,12 +46,24 @@
             }
         }
 
-        $serverList = $serverList | Where-Object { $_.Name -notin $Name }
+        $remainingServers = [System.Collections.Generic.List[AtlassianPS.ServerData]]::new()
+        foreach ($server in $serverList) {
+            if ($server.Name -notin $Name) {
+                $remainingServers.Add($server)
+            }
+        }
+        $serverList = $remainingServers
     }
 
     end {
         Write-DebugMessage "Persisting ServerList"
-        $script:Configuration.ServerList = $serverList
+        $persistedServerList = [System.Collections.Generic.List[AtlassianPS.ServerData]]::new()
+        foreach ($server in $serverList) {
+            $persistedServerList.Add($server)
+        }
+
+        $script:Configuration.Remove("ServerList")
+        $script:Configuration.Add("ServerList", $persistedServerList)
         Save-Configuration
 
         Write-Verbose "Function ended"

--- a/AtlassianPS.Configuration/Public/Set-Configuration.ps1
+++ b/AtlassianPS.Configuration/Public/Set-Configuration.ps1
@@ -36,7 +36,7 @@
     begin {
         Write-Verbose "Function started"
 
-        $reservedNames = @('ServerList', 'Message')
+        $reservedNames = @('ServerList')
     }
 
     process {

--- a/AtlassianPS.Configuration/Public/Set-Configuration.ps1
+++ b/AtlassianPS.Configuration/Public/Set-Configuration.ps1
@@ -35,25 +35,44 @@
 
     begin {
         Write-Verbose "Function started"
+
+        $reservedNames = @('ServerList', 'Message')
     }
 
     process {
         Write-DebugMessage "ParameterSetName: $($PsCmdlet.ParameterSetName)"
         Write-DebugMessage "PSBoundParameters: $($PSBoundParameters | Out-String)"
 
+        if ($Name -in $reservedNames) {
+            $writeErrorSplat = @{
+                ExceptionType = "System.ApplicationException"
+                Message       = "Configuration key [$Name] is reserved and cannot be changed with Set-Configuration"
+                ErrorId       = "AtlassianPS.Configuration.ReservedKey"
+                Category      = "InvalidArgument"
+                TargetObject  = $Name
+            }
+            WriteError @writeErrorSplat
+            return
+        }
+
         if ($Append) {
             Write-Verbose "Appending to existing value"
             $oldValue = (Get-Configuration -Name $Name -ValueOnly)
-            try {
-                $newValue = @(@($oldValue) + @($Value)) -as ($oldValue.GetType())
-                if (-not $newValue) {
-                    throw "failed to case to $($oldValue.GetType().Name)"
-                }
+            if ($null -eq $oldValue) {
+                $newValue = @($Value)
             }
-            catch {
-                Write-DebugMessage $_
+            else {
+                try {
+                    $newValue = @(@($oldValue) + @($Value)) -as ($oldValue.GetType())
+                    if (-not $newValue) {
+                        throw "failed to cast to $($oldValue.GetType().Name)"
+                    }
+                }
+                catch {
+                    Write-DebugMessage $_
 
-                $newValue = @(@($oldValue) + @($Value))
+                    $newValue = @(@($oldValue) + @($Value))
+                }
             }
             $Value = $newValue
         }

--- a/AtlassianPS.Configuration/Public/Set-ServerConfiguration.ps1
+++ b/AtlassianPS.Configuration/Public/Set-ServerConfiguration.ps1
@@ -5,12 +5,14 @@
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseShouldProcessForStateChangingFunctions', '')]
     param(
         [Parameter( Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName )]
+        [ValidateRange(1, [UInt32]::MaxValue)]
         [UInt32]
         $Id,
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [Alias('Url', 'Address')]
+        [ValidateScript( { $_.IsAbsoluteUri } )]
         [Uri]
         $Uri,
 
@@ -61,6 +63,18 @@
 
         $serverEntry = Get-ServerConfiguration | Where-Object { $_.Id -eq $Id }
         if ($serverEntry) {
+            if ($PSBoundParameters.ContainsKey('Name') -and (Get-ServerConfiguration | Where-Object { $_.Id -ne $Id -and $_.Name -eq $Name })) {
+                $writeErrorSplat = @{
+                    ExceptionType = "System.ApplicationException"
+                    Message       = "An entry with name [$Name] already exists"
+                    ErrorId       = "AtlassianPS.ServerData.EntryExists"
+                    Category      = "InvalidData"
+                    TargetObject  = $Name
+                }
+                WriteError @writeErrorSplat
+                return
+            }
+
             foreach ($property in ($PSBoundParameters.Keys | Where-Object { $_ -notin $parametersToIgnore } )) {
                 Write-Verbose "Changing [$property] of entry #$Id"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `Write-VerboseMessage` as a public shared runtime helper for formatted verbose output without shadowing PowerShell's built-in `Write-Verbose`.
 - Moved shared runtime helper implementations from `AtlassianPS.Standards` into `AtlassianPS.Configuration` to keep standards tooling-focused.
 
+### Fixed
+
+- Preserved in-memory server sessions while exporting sanitized configuration.
+- Fixed server add/remove/update edge cases around duplicate names, pipeline input, URI validation, and empty server lists.
+- Protected the internal `ServerList` key from generic configuration mutation while keeping `Message` configurable.
+- Corrected first-use and command documentation for server configuration commands.
+
 ## 0.2 - 2018-10-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $serverData = @{
     # Type of the Atlassian product
     Type = "Confluence"
 }
-Set-AtlassianServerConfiguration @serverData
+Add-AtlassianServerConfiguration @serverData
 
 Get-ConfluenceSpace -Server "AtlassianPS - wiki"
 ```

--- a/Tests/Functions/Add-ServerConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Add-ServerConfiguration.Unit.Tests.ps1
@@ -140,6 +140,28 @@ Describe "Add-ServerConfiguration" -Tag Unit {
                 (Get-ServerConfiguration).Id | Should -Be @(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
             }
 
+            It "adds piped servers with unique names and IDs" {
+                @(
+                    [PSCustomObject]@{ Name = "New Server 1"; Uri = "https://one.atlassianps.org"; Type = "Jira" }
+                    [PSCustomObject]@{ Name = "New Server 2"; Uri = "https://two.atlassianps.org"; Type = "Jira" }
+                ) | Add-ServerConfiguration
+
+                Get-ServerConfiguration | Should -HaveCount 4
+                (Get-ServerConfiguration).Id | Should -Be @(1, 2, 3, 4)
+                (Get-ServerConfiguration).Name | Should -Contain "New Server 1"
+                (Get-ServerConfiguration).Name | Should -Contain "New Server 2"
+            }
+
+            It "rejects duplicate names within one pipeline invocation" {
+                @(
+                    [PSCustomObject]@{ Name = "New Server"; Uri = "https://one.atlassianps.org"; Type = "Jira" }
+                    [PSCustomObject]@{ Name = "New Server"; Uri = "https://two.atlassianps.org"; Type = "Jira" }
+                ) | Add-ServerConfiguration -ErrorAction SilentlyContinue
+
+                Get-ServerConfiguration | Should -HaveCount 3
+                (Get-ServerConfiguration | Where-Object Name -eq "New Server") | Should -HaveCount 1
+            }
+
             It "writes an error if the Name already exists in the collection" {
                 Get-ServerConfiguration | Should -HaveCount 2
                 (Get-ServerConfiguration).Name | Should -Contain "Google"
@@ -207,6 +229,8 @@ Describe "Add-ServerConfiguration" -Tag Unit {
 
                 { Add-ServerConfiguration -Name "None" -Uri "https://atlassianps.org" -Type "" } | Should -Throw
                 { Add-ServerConfiguration -Name "Github" -Uri "https://atlassianps.org" -Type Github } | Should -Throw
+
+                { Add-ServerConfiguration -Name "Relative" -Uri "relative/path" -Type Jira } | Should -Throw
 
                 Get-ServerConfiguration | Should -HaveCount 5
             }

--- a/Tests/Functions/Remove-Configuration.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-Configuration.Unit.Tests.ps1
@@ -90,7 +90,9 @@ Describe "Remove-Configuration" -Tag Unit {
             It "accepts an object over the pipeline" {
                 Get-Configuration | Should -HaveCount 4
 
-                Get-Configuration | Remove-Configuration
+                Get-Configuration |
+                    Where-Object Name -ne "ServerList" |
+                    Remove-Configuration
 
                 Get-Configuration | Should -HaveCount 1
                 Get-Configuration | Where-Object Name -eq "ServerList" | Should -Not -BeNullOrEmpty

--- a/Tests/Functions/Remove-Configuration.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-Configuration.Unit.Tests.ps1
@@ -92,7 +92,8 @@ Describe "Remove-Configuration" -Tag Unit {
 
                 Get-Configuration | Remove-Configuration
 
-                Get-Configuration | Should -HaveCount 0
+                Get-Configuration | Should -HaveCount 1
+                Get-Configuration | Where-Object Name -eq "ServerList" | Should -Not -BeNullOrEmpty
             }
 
             It "accepts strings over the pipeline" {
@@ -113,6 +114,12 @@ Describe "Remove-Configuration" -Tag Unit {
                 Get-Configuration | Should -HaveCount 3
                 Get-Configuration | Where-Object Name -eq "Foo" | Should -BeNullOrEmpty
                 Get-Configuration | Where-Object Name -eq "Bar" | Should -Not -BeNullOrEmpty
+            }
+
+            It "does not allow reserved configuration keys to be removed" {
+                { Remove-Configuration -Name "ServerList" -ErrorAction Stop } | Should -Throw
+
+                Get-Configuration | Where-Object Name -eq "ServerList" | Should -Not -BeNullOrEmpty
             }
         }
     }

--- a/Tests/Functions/Remove-Configuration.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-Configuration.Unit.Tests.ps1
@@ -121,6 +121,14 @@ Describe "Remove-Configuration" -Tag Unit {
 
                 Get-Configuration | Where-Object Name -eq "ServerList" | Should -Not -BeNullOrEmpty
             }
+
+            It "allows the Message configuration key to be removed" {
+                $script:Configuration["Message"] = [AtlassianPS.MessageStyle]::new()
+
+                Remove-Configuration -Name "Message"
+
+                Get-Configuration | Where-Object Name -eq "Message" | Should -BeNullOrEmpty
+            }
         }
     }
 }

--- a/Tests/Functions/Remove-ServerConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-ServerConfiguration.Unit.Tests.ps1
@@ -76,6 +76,7 @@ Describe "Remove-ServerConfiguration" -Tag Unit {
                 Remove-ServerConfiguration -Name "Google", "Google with Session"
 
                 Get-ServerConfiguration | Should -BeNullOrEmpty
+                $script:Configuration["ServerList"].GetType() | Should -Be ([System.Collections.Generic.List[AtlassianPS.ServerData]])
             }
 
             It "accepts an object over the pipeline" {
@@ -96,6 +97,7 @@ Describe "Remove-ServerConfiguration" -Tag Unit {
                 "Google", "Google with Session" | Remove-ServerConfiguration
 
                 Get-ServerConfiguration | Should -BeNullOrEmpty
+                $script:Configuration["ServerList"].GetType() | Should -Be ([System.Collections.Generic.List[AtlassianPS.ServerData]])
             }
 
             It "writes an error when the server could not be removed" {

--- a/Tests/Functions/Save-Configuration.Unit.Tests.ps1
+++ b/Tests/Functions/Save-Configuration.Unit.Tests.ps1
@@ -81,6 +81,14 @@ Describe "Save-Configuration" -Tag Unit {
                 ($before["ServerList"] | Where-Object Session | Select-Object -First 1).Session.UserAgent | Should -Not -BeNullOrEmpty
                 ($after["ServerList"] | Where-Object Name -eq "Google with Session" | Select-Object -First 1).Session | Should -BeNullOrEmpty
             }
+
+            It "does not clear sessions from the live configuration" {
+                $before = Get-Configuration -AsHashtable
+
+                Save-Configuration
+
+                ($before["ServerList"] | Where-Object Name -eq "Google with Session" | Select-Object -First 1).Session.UserAgent | Should -Not -BeNullOrEmpty
+            }
         }
     }
 }

--- a/Tests/Functions/Set-Configuration.Unit.Tests.ps1
+++ b/Tests/Functions/Set-Configuration.Unit.Tests.ps1
@@ -111,6 +111,18 @@ Describe "Set-Configuration" -Tag Unit {
                 (Get-Configuration | Where-Object Name -eq "Bar").Value | Should -Contain 100
             }
 
+            It "appends a value to a new entry without a leading null" {
+                Set-Configuration -Name "NewKey" -Value "New Value" -Append
+
+                (Get-Configuration | Where-Object Name -eq "NewKey").Value | Should -Be @("New Value")
+            }
+
+            It "does not allow reserved configuration keys to be changed" {
+                { Set-Configuration -Name "ServerList" -Value "broken" -ErrorAction Stop } | Should -Throw
+
+                $script:Configuration.ServerList | Should -Not -Be "broken"
+            }
+
             It "allows value to be passed over pipeline for a new entry" {
                 Get-Configuration | Should -HaveCount 4
                 (Get-Configuration | Where-Object Name -eq "NewKey").Value | Should -BeNullOrEmpty

--- a/Tests/Functions/Set-Configuration.Unit.Tests.ps1
+++ b/Tests/Functions/Set-Configuration.Unit.Tests.ps1
@@ -123,6 +123,15 @@ Describe "Set-Configuration" -Tag Unit {
                 $script:Configuration.ServerList | Should -Not -Be "broken"
             }
 
+            It "allows the Message configuration key to be changed" {
+                $messageStyle = [AtlassianPS.MessageStyle]::new(2, $false, $true, $false)
+
+                Set-Configuration -Name "Message" -Value $messageStyle
+
+                (Get-Configuration -Name "Message" -ValueOnly).Indent | Should -Be 2
+                (Get-Configuration -Name "Message" -ValueOnly).BreadCrumbs | Should -BeTrue
+            }
+
             It "allows value to be passed over pipeline for a new entry" {
                 Get-Configuration | Should -HaveCount 4
                 (Get-Configuration | Where-Object Name -eq "NewKey").Value | Should -BeNullOrEmpty

--- a/Tests/Functions/Set-ServerConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Set-ServerConfiguration.Unit.Tests.ps1
@@ -129,9 +129,15 @@ Describe "Set-ServerConfiguration" -Tag Unit {
 
             It "writes an error if the index does not exist" {
                 { Set-ServerConfiguration -Id 1 -Name "New Server" -ErrorAction Stop } | Should -Not -Throw
-                { Set-ServerConfiguration -Id 2 -Name "New Server" -ErrorAction Stop } | Should -Not -Throw
+                { Set-ServerConfiguration -Id 2 -Name "Other New Server" -ErrorAction Stop } | Should -Not -Throw
                 { Set-ServerConfiguration -Id 3 -Name "New Server" -ErrorAction Stop } | Should -Throw "No entry could be found at index 3"
                 { Set-ServerConfiguration -Id 3 -Name "New Server" -ErrorAction SilentlyContinue } | Should -Not -Throw
+            }
+
+            It "rejects duplicate names" {
+                { Set-ServerConfiguration -Id 1 -Name "Google with Session" -ErrorAction Stop } | Should -Throw
+
+                (Get-ServerConfiguration | Where-Object Id -eq 1).Name | Should -Be "Google"
             }
         }
 
@@ -196,6 +202,8 @@ Describe "Set-ServerConfiguration" -Tag Unit {
 
                 { Set-ServerConfiguration -Id 1 -Name "None" -Uri "https://atlassianps.org" -Type "" } | Should -Throw
                 { Set-ServerConfiguration -Id 1 -Name "Github" -Uri "https://atlassianps.org" -Type Github } | Should -Throw
+                { Set-ServerConfiguration -Id 1 -Uri "relative/path" } | Should -Throw
+                { Set-ServerConfiguration -Id 0 -Name "Invalid" } | Should -Throw
 
                 Get-ServerConfiguration | Should -HaveCount 2
             }

--- a/docs/en-US/about_AtlassianPS.Configuration.md
+++ b/docs/en-US/about_AtlassianPS.Configuration.md
@@ -61,7 +61,7 @@ $serverData = @{
     # Type of the Atlassian product
     Type = "Confluence"
 }
-Set-AtlassianServerConfiguration @serverData
+Add-AtlassianServerConfiguration @serverData
 
 Get-ConfluenceSpace -Server "AtlassianPS - wiki"
 ```

--- a/docs/en-US/commands/Add-ServerConfiguration.md
+++ b/docs/en-US/commands/Add-ServerConfiguration.md
@@ -74,7 +74,7 @@ Name with which this server will be stored.
 If no name is provided, the "Authority" of the address will be used.
 This value must be unique.
 
-In case the ServerName was already saved, it will be overwritten.
+In case the ServerName was already saved, an error is written and the existing entry is not changed.
 
 Example for "Authority":
   `https://**www.google.com**/maps?hl=en` --> `www.google.com`

--- a/docs/en-US/commands/Remove-ServerConfiguration.md
+++ b/docs/en-US/commands/Remove-ServerConfiguration.md
@@ -47,7 +47,7 @@ This command will remove all stored servers.
 
 Name with which this server is stored.
 
-Is case sensitive
+Is not case sensitive
 
 ```yaml
 Type: String[]

--- a/docs/en-US/commands/Set-ServerConfiguration.md
+++ b/docs/en-US/commands/Set-ServerConfiguration.md
@@ -97,7 +97,7 @@ Name with which this server will be stored.
 If no name is provided, the "Authority" of the address will be used.
 This value must be unique.
 
-In case the ServerName was already saved, it will be overwritten.
+In case the ServerName was already saved for another entry, an error is written and the existing entries are not changed.
 
 Example for "Authority":
   https://**www.google.com**/maps?hl=en --> "www.google.com"


### PR DESCRIPTION
## Summary
- preserve live server sessions while exporting sanitized configuration
- make server add/remove/update operations type-safe and duplicate-safe
- protect reserved configuration keys from generic mutation
- correct first-use and command documentation
- add regression coverage for release-readiness fixes

## Tests
- pwsh -NoLogo -NonInteractive -NoProfile -Command "Set-Location '/Users/LIO2MU/projects/AtlassianPS/agents/config-release-readiness/AtlassianPS.Configuration'; Invoke-Build -Task Build, Test"