### PR TITLE
Add ShouldProcess support to mutating commands

### DIFF
--- a/AtlassianPS.Configuration/Private/Import-MqcnAlias.ps1
+++ b/AtlassianPS.Configuration/Private/Import-MqcnAlias.ps1
@@ -27,6 +27,6 @@
     )
 
     begin {
-        Set-Alias -Name $Alias -Value $Command -Scope 1
+        Set-Alias -Name $Alias -Value $Command -Scope 1 -WhatIf:$false
     }
 }

--- a/AtlassianPS.Configuration/Public/Add-ServerConfiguration.ps1
+++ b/AtlassianPS.Configuration/Public/Add-ServerConfiguration.ps1
@@ -1,6 +1,6 @@
 ﻿function Add-ServerConfiguration {
     # .ExternalHelp ..\AtlassianPS.Configuration-help.xml
-    [CmdletBinding()]
+    [CmdletBinding( ConfirmImpact = 'Low', SupportsShouldProcess = $true )]
     [OutputType( [void] )]
     param(
         [Parameter( Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName )]
@@ -35,6 +35,8 @@
         foreach ($server in @(Get-ServerConfiguration)) {
             $serverList.Add($server)
         }
+
+        $configurationChanged = $false
     }
 
     process {
@@ -54,7 +56,7 @@
             }
             WriteError @writeErrorSplat
         }
-        else {
+        elseif ($PSCmdlet.ShouldProcess($entryName, "Add server configuration")) {
             if (-not ($index = ($serverList.Id | Measure-Object -Maximum).Maximum)) {
                 $index = 0
             }
@@ -73,13 +75,16 @@
             Write-Verbose "Adding server #$($index): [$($config.Name)]"
             Write-DebugMessage "Adding server `$config: $($config.Name) @ index $index" -BreakPoint
             $serverList.Add($config)
+            $configurationChanged = $true
         }
     }
 
     end {
-        Write-DebugMessage "Persisting ServerList"
-        $script:Configuration["ServerList"] = $serverList
-        Save-Configuration
+        if ($configurationChanged) {
+            Write-DebugMessage "Persisting ServerList"
+            $script:Configuration["ServerList"] = $serverList
+            Save-Configuration
+        }
 
         Write-Verbose "Function ended"
     }

--- a/AtlassianPS.Configuration/Public/Remove-Configuration.ps1
+++ b/AtlassianPS.Configuration/Public/Remove-Configuration.ps1
@@ -1,8 +1,7 @@
 ﻿function Remove-Configuration {
     # .ExternalHelp ..\AtlassianPS.Configuration-help.xml
-    [CmdletBinding( ConfirmImpact = 'Low', SupportsShouldProcess = $false )]
+    [CmdletBinding( ConfirmImpact = 'Low', SupportsShouldProcess = $true )]
     [OutputType( [void] )]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage( 'PSUseShouldProcessForStateChangingFunctions', '' )]
     param(
         [Parameter( Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName )]
         [ValidateNotNullOrEmpty()]
@@ -24,6 +23,7 @@
         Write-Verbose "Function started"
 
         $reservedNames = @('ServerList')
+        $configurationChanged = $false
     }
 
     process {
@@ -45,12 +45,16 @@
 
             Write-Verbose "Filtering for [name = $_name]"
 
-            $script:Configuration.Remove($_name)
+            if ($PSCmdlet.ShouldProcess($_name, "Remove configuration key")) {
+                $configurationChanged = $script:Configuration.Remove($_name) -or $configurationChanged
+            }
         }
     }
 
     end {
-        Save-Configuration
+        if ($configurationChanged) {
+            Save-Configuration
+        }
 
         Write-Verbose "Function ended"
     }

--- a/AtlassianPS.Configuration/Public/Remove-ServerConfiguration.ps1
+++ b/AtlassianPS.Configuration/Public/Remove-ServerConfiguration.ps1
@@ -1,8 +1,7 @@
 ﻿function Remove-ServerConfiguration {
     # .ExternalHelp ..\AtlassianPS.Configuration-help.xml
-    [CmdletBinding( ConfirmImpact = 'Low', SupportsShouldProcess = $false )]
+    [CmdletBinding( ConfirmImpact = 'Low', SupportsShouldProcess = $true )]
     [OutputType( [void] )]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseShouldProcessForStateChangingFunctions', '')]
     param(
         [Parameter( Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName )]
         [ArgumentCompleter( {
@@ -26,6 +25,8 @@
         foreach ($server in @(Get-ServerConfiguration)) {
             $serverList.Add($server)
         }
+
+        $configurationChanged = $false
     }
 
     process {
@@ -46,20 +47,27 @@
             }
         }
 
-        $remainingServers = [System.Collections.Generic.List[AtlassianPS.ServerData]]::new()
-        foreach ($server in $serverList) {
-            if ($server.Name -notin $Name) {
-                $remainingServers.Add($server)
+        foreach ($serverToRemove in $Name) {
+            if ($serverToRemove -in $serverList.Name -and $PSCmdlet.ShouldProcess($serverToRemove, "Remove server configuration")) {
+                $remainingServers = [System.Collections.Generic.List[AtlassianPS.ServerData]]::new()
+                foreach ($server in $serverList) {
+                    if ($server.Name -ne $serverToRemove) {
+                        $remainingServers.Add($server)
+                    }
+                }
+                $serverList = $remainingServers
+                $configurationChanged = $true
             }
         }
-        $serverList = $remainingServers
     }
 
     end {
-        Write-DebugMessage "Persisting ServerList"
-        $script:Configuration.Remove("ServerList")
-        $script:Configuration.Add("ServerList", $serverList)
-        Save-Configuration
+        if ($configurationChanged) {
+            Write-DebugMessage "Persisting ServerList"
+            $script:Configuration.Remove("ServerList")
+            $script:Configuration.Add("ServerList", $serverList)
+            Save-Configuration
+        }
 
         Write-Verbose "Function ended"
     }

--- a/AtlassianPS.Configuration/Public/Set-Configuration.ps1
+++ b/AtlassianPS.Configuration/Public/Set-Configuration.ps1
@@ -1,8 +1,7 @@
 ﻿function Set-Configuration {
     # .ExternalHelp ..\AtlassianPS.Configuration-help.xml
-    [CmdletBinding( ConfirmImpact = 'Low', SupportsShouldProcess = $false )]
+    [CmdletBinding( ConfirmImpact = 'Low', SupportsShouldProcess = $true )]
     [OutputType( [PSCustomObject] )]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage( 'PSUseShouldProcessForStateChangingFunctions', '' )]
     param(
         [Parameter( Mandatory, ValueFromPipelineByPropertyName )]
         [ValidateNotNullOrEmpty()]
@@ -37,6 +36,7 @@
         Write-Verbose "Function started"
 
         $reservedNames = @('ServerList')
+        $configurationChanged = $false
     }
 
     process {
@@ -81,16 +81,21 @@
         else { $dataType = "null" }
         Write-Verbose "Storing value [$dataType] to [name = $Name]"
 
-        $script:Configuration.Remove($Name)
-        $script:Configuration.Add($Name, $Value)
+        if ($PSCmdlet.ShouldProcess($Name, "Set configuration value")) {
+            $script:Configuration.Remove($Name)
+            $script:Configuration.Add($Name, $Value)
+            $configurationChanged = $true
 
-        if ($Passthru) {
-            Get-Configuration -Name $Name
+            if ($Passthru) {
+                Get-Configuration -Name $Name
+            }
         }
     }
 
     end {
-        Save-Configuration
+        if ($configurationChanged) {
+            Save-Configuration
+        }
 
         Write-Verbose "Function ended"
     }

--- a/AtlassianPS.Configuration/Public/Set-ServerConfiguration.ps1
+++ b/AtlassianPS.Configuration/Public/Set-ServerConfiguration.ps1
@@ -1,8 +1,7 @@
 ﻿function Set-ServerConfiguration {
     # .ExternalHelp ..\AtlassianPS.Configuration-help.xml
-    [CmdletBinding( ConfirmImpact = 'Low', SupportsShouldProcess = $false )]
+    [CmdletBinding( ConfirmImpact = 'Low', SupportsShouldProcess = $true )]
     [OutputType( [void] )]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseShouldProcessForStateChangingFunctions', '')]
     param(
         [Parameter( Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName )]
         [ValidateRange(1, [UInt32]::MaxValue)]
@@ -52,9 +51,8 @@
             'OutVariable'
             'OutBuffer'
             'PipelineVariable'
-            'WhatIf'
-            'Confirm'
         )
+        $configurationChanged = $false
     }
 
     process {
@@ -75,10 +73,13 @@
                 return
             }
 
-            foreach ($property in ($PSBoundParameters.Keys | Where-Object { $_ -notin $parametersToIgnore } )) {
-                Write-Verbose "Changing [$property] of entry #$Id"
+            if ($PSCmdlet.ShouldProcess("#$Id ($($serverEntry.Name))", "Update server configuration")) {
+                foreach ($property in ($PSBoundParameters.Keys | Where-Object { $_ -notin $parametersToIgnore } )) {
+                    Write-Verbose "Changing [$property] of entry #$Id"
 
-                $serverEntry.$property = Get-Variable $property -ValueOnly
+                    $serverEntry.$property = Get-Variable $property -ValueOnly
+                    $configurationChanged = $true
+                }
             }
         }
         else {
@@ -94,7 +95,9 @@
     }
 
     end {
-        Save-Configuration
+        if ($configurationChanged) {
+            Save-Configuration
+        }
 
         Write-Verbose "Function ended"
     }

--- a/AtlassianPS.Configuration/Public/Set-ServerConfiguration.ps1
+++ b/AtlassianPS.Configuration/Public/Set-ServerConfiguration.ps1
@@ -51,6 +51,8 @@
             'OutVariable'
             'OutBuffer'
             'PipelineVariable'
+            'WhatIf'
+            'Confirm'
         )
         $configurationChanged = $false
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Improvements
 
+- Added `-WhatIf` and `-Confirm` support to mutating configuration and server configuration commands.
 - Migrated `Tools/setup.ps1` to shared `AtlassianPS.Standards` bootstrap/dependency commands with synchronized ScriptAnalyzer settings.
 - Migrated `Tools/update.dependencies.ps1` to shared `AtlassianPS.Standards\Update-AtlassianPSDependencyReference` with `ShouldProcess` and fail-fast behavior.
 - Aligned workflow setup pins and build/release standards version references to `AtlassianPS.Standards` `0.1.6`.

--- a/Tests/Functions/Add-ServerConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Add-ServerConfiguration.Unit.Tests.ps1
@@ -92,6 +92,14 @@ Describe "Add-ServerConfiguration" -Tag Unit {
                 (Get-ServerConfiguration).Name | Should -Contain "New Server"
             }
 
+            It "does not add or save a server when WhatIf is used" {
+                Add-ServerConfiguration -Name "New Server" -Uri "https://atlassianps.org" -Type Jira -WhatIf
+
+                Get-ServerConfiguration | Should -HaveCount 2
+                (Get-ServerConfiguration).Name | Should -Not -Contain "New Server"
+                Should -Invoke "Save-Configuration" -ModuleName "AtlassianPS.Configuration" -Exactly -Times 0 -Scope It
+            }
+
             It "uses the [Uri]::Authority as default for server's name" {
                 Get-ServerConfiguration | Should -HaveCount 2
                 (Get-ServerConfiguration).Name | Should -Not -Contain "atlassianps.org"

--- a/Tests/Functions/Remove-Configuration.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-Configuration.Unit.Tests.ps1
@@ -8,22 +8,24 @@ Describe "Remove-Configuration" -Tag Unit {
     }
 
     InModuleScope "AtlassianPS.Configuration" {
-        #region Mocking
-        Mock Write-DebugMessage -ModuleName "AtlassianPS.Configuration" {}
-        Mock Write-Verbose -ModuleName "AtlassianPS.Configuration" {}
-        Mock Save-Configuration -ModuleName "AtlassianPS.Configuration" {}
+        BeforeEach {
+            #region Mocking
+            Mock Write-DebugMessage -ModuleName "AtlassianPS.Configuration" {}
+            Mock Write-Verbose -ModuleName "AtlassianPS.Configuration" {}
+            Mock Save-Configuration -ModuleName "AtlassianPS.Configuration" {}
 
-        Mock Get-Configuration {
-            $tempConfig = $script:Configuration.Clone()
-            $tempConfig.Keys |
-                ForEach-Object {
-                    [PSCustomObject]@{
-                        Name  = $_
-                        Value = $tempConfig[$_]
+            Mock Get-Configuration {
+                $tempConfig = $script:Configuration.Clone()
+                $tempConfig.Keys |
+                    ForEach-Object {
+                        [PSCustomObject]@{
+                            Name  = $_
+                            Value = $tempConfig[$_]
+                        }
                     }
-                }
+            }
+            #endregion Mocking
         }
-        #endregion Mocking
 
         Context "Sanity checking" {
             BeforeAll {
@@ -71,6 +73,14 @@ Describe "Remove-Configuration" -Tag Unit {
                 Get-Configuration | Should -HaveCount 3
                 Get-Configuration | Where-Object Name -eq "Foo" | Should -BeNullOrEmpty
                 Get-Configuration | Where-Object Name -eq "Bar" | Should -Not -BeNullOrEmpty
+            }
+
+            It "does not remove or save a configuration key when WhatIf is used" {
+                Remove-Configuration -Name "Foo" -WhatIf
+
+                Get-Configuration | Should -HaveCount 4
+                Get-Configuration | Where-Object Name -eq "Foo" | Should -Not -BeNullOrEmpty
+                Should -Invoke "Save-Configuration" -ModuleName "AtlassianPS.Configuration" -Exactly -Times 0 -Scope It
             }
 
             It "removes multiple entries at once" {

--- a/Tests/Functions/Remove-ServerConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-ServerConfiguration.Unit.Tests.ps1
@@ -8,15 +8,17 @@ Describe "Remove-ServerConfiguration" -Tag Unit {
     }
 
     InModuleScope "AtlassianPS.Configuration" {
-        #region Mocking
-        Mock Write-DebugMessage -ModuleName "AtlassianPS.Configuration" {}
-        Mock Write-Verbose -ModuleName "AtlassianPS.Configuration" {}
-        Mock Save-Configuration -ModuleName "AtlassianPS.Configuration" {}
+        BeforeEach {
+            #region Mocking
+            Mock Write-DebugMessage -ModuleName "AtlassianPS.Configuration" {}
+            Mock Write-Verbose -ModuleName "AtlassianPS.Configuration" {}
+            Mock Save-Configuration -ModuleName "AtlassianPS.Configuration" {}
 
-        Mock Get-ServerConfiguration {
-            $script:Configuration["ServerList"]
+            Mock Get-ServerConfiguration {
+                $script:Configuration["ServerList"]
+            }
+            #endregion Mocking
         }
-        #endregion Mocking
 
         Context "Sanity checking" {
             BeforeAll {
@@ -68,6 +70,14 @@ Describe "Remove-ServerConfiguration" -Tag Unit {
                 Remove-ServerConfiguration -Name "Google"
 
                 Get-ServerConfiguration | Should -HaveCount 1
+            }
+
+            It "does not remove or save a server when WhatIf is used" {
+                Remove-ServerConfiguration -Name "Google" -WhatIf
+
+                Get-ServerConfiguration | Should -HaveCount 2
+                (Get-ServerConfiguration).Name | Should -Contain "Google"
+                Should -Invoke "Save-Configuration" -ModuleName "AtlassianPS.Configuration" -Exactly -Times 0 -Scope It
             }
 
             It "removes multiple entries of the servers" {

--- a/Tests/Functions/Set-Configuration.Unit.Tests.ps1
+++ b/Tests/Functions/Set-Configuration.Unit.Tests.ps1
@@ -8,29 +8,31 @@ Describe "Set-Configuration" -Tag Unit {
     }
 
     InModuleScope "AtlassianPS.Configuration" {
-        #region Mocking
-        Mock Write-DebugMessage -ModuleName "AtlassianPS.Configuration" {}
-        Mock Write-Verbose -ModuleName "AtlassianPS.Configuration" {}
-        Mock Save-Configuration -ModuleName "AtlassianPS.Configuration" {}
+        BeforeEach {
+            #region Mocking
+            Mock Write-DebugMessage -ModuleName "AtlassianPS.Configuration" {}
+            Mock Write-Verbose -ModuleName "AtlassianPS.Configuration" {}
+            Mock Save-Configuration -ModuleName "AtlassianPS.Configuration" {}
 
-        Mock Get-Configuration {
-            $tempConfig = $script:Configuration.Clone()
-            $return = $tempConfig.Keys |
-                ForEach-Object {
-                    [PSCustomObject]@{
-                        Name  = $_
-                        Value = $tempConfig[$_]
+            Mock Get-Configuration {
+                $tempConfig = $script:Configuration.Clone()
+                $return = $tempConfig.Keys |
+                    ForEach-Object {
+                        [PSCustomObject]@{
+                            Name  = $_
+                            Value = $tempConfig[$_]
+                        }
                     }
+                if ($Name) {
+                    $return = $return | Where-Object Name -eq $Name
                 }
-            if ($Name) {
-                $return = $return | Where-Object Name -eq $Name
+                if ($ValueOnly) {
+                    $return = $return.Value
+                }
+                $return
             }
-            if ($ValueOnly) {
-                $return = $return.Value
-            }
-            $return
+            #endregion Mocking
         }
-        #endregion Mocking
 
         Context "Sanity checking" {
             BeforeAll {
@@ -98,6 +100,13 @@ Describe "Set-Configuration" -Tag Unit {
 
                 Get-Configuration | Should -HaveCount 4
                 (Get-Configuration | Where-Object Name -eq "Foo").Value | Should -Not -BeNullOrEmpty
+            }
+
+            It "does not set or save a configuration value when WhatIf is used" {
+                Set-Configuration -Name "Foo" -Value "New Value" -WhatIf
+
+                (Get-Configuration | Where-Object Name -eq "Foo").Value | Should -Be "lorem ipsum"
+                Should -Invoke "Save-Configuration" -ModuleName "AtlassianPS.Configuration" -Exactly -Times 0 -Scope It
             }
 
             It "appends a value to an entry" {

--- a/Tests/Functions/Set-ServerConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Set-ServerConfiguration.Unit.Tests.ps1
@@ -103,6 +103,13 @@ Describe "Set-ServerConfiguration" -Tag Unit {
                 Should -Invoke "Save-Configuration" -ModuleName "AtlassianPS.Configuration" -Exactly -Times 0 -Scope It
             }
 
+            It "ignores Confirm when updating a server" {
+                Set-ServerConfiguration -Id 1 -Name "New Server" -Confirm:$false
+
+                (Get-ServerConfiguration | Where-Object Id -eq 1).Name | Should -Be "New Server"
+                Should -Invoke "Save-Configuration" -ModuleName "AtlassianPS.Configuration" -Exactly -Times 1 -Scope It
+            }
+
             It "accepts the Id over the pipeline" {
                 (Get-ServerConfiguration).Name | Should -Not -Contain "New Server"
 

--- a/Tests/Functions/Set-ServerConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Set-ServerConfiguration.Unit.Tests.ps1
@@ -95,6 +95,14 @@ Describe "Set-ServerConfiguration" -Tag Unit {
                 (Get-ServerConfiguration | Where-Object Id -eq 1).Name | Should -Be "New Server"
             }
 
+            It "does not update or save a server when WhatIf is used" {
+                Set-ServerConfiguration -Id 1 -Name "New Server" -WhatIf
+
+                (Get-ServerConfiguration).Name | Should -Not -Contain "New Server"
+                (Get-ServerConfiguration | Where-Object Id -eq 1).Name | Should -Be "Google"
+                Should -Invoke "Save-Configuration" -ModuleName "AtlassianPS.Configuration" -Exactly -Times 0 -Scope It
+            }
+
             It "accepts the Id over the pipeline" {
                 (Get-ServerConfiguration).Name | Should -Not -Contain "New Server"
 


### PR DESCRIPTION
## Summary
- Add ShouldProcess support to mutating configuration and server configuration commands
- Skip persistence when WhatIf declines mutation
- Add WhatIf regression coverage for add/set/remove command paths
- Keep module-qualified alias helpers active under WhatIf

## Validation
- pwsh -NoLogo -NonInteractive -NoProfile -Command "Set-Location '/Users/LIO2MU/projects/AtlassianPS/agents/config-release-readiness/AtlassianPS.Configuration'; Invoke-Build -Task Build, Test"
- Tests Passed: 942, Failed: 0, Skipped: 19
