### PR TITLE
Add website docs indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,32 @@ Get-ConfluenceSpace -Server "AtlassianPS - wiki"
 
 You can find the full documentation on our [homepage](https://atlassianps.org/docs/AtlassianPS.Configuration) and in the console.
 
+```powershell
+# Review the help at any time!
+Get-Help about_AtlassianPS.Configuration
+Get-Command -Module AtlassianPS.Configuration
+Get-Help Get-AtlassianServerConfiguration -Full # or any other command
+```
+
 ### Contribute
 
 Want to contribute to AtlassianPS? Great!
 We appreciate [everyone](https://atlassianps.org/#people) who invests their time to make our modules the best they can be.
 
 Check out our guidelines on [Contributing] to our modules and documentation.
+
+## Tested on
+
+| Configuration | Status |
+| ------------- | ------ |
+| Windows PowerShell v5.1 | [CI workflow](https://github.com/AtlassianPS/AtlassianPS.Configuration/actions/workflows/ci.yml) |
+| PowerShell 7 on Windows | [CI workflow](https://github.com/AtlassianPS/AtlassianPS.Configuration/actions/workflows/ci.yml) |
+| PowerShell 7 on Ubuntu | [CI workflow](https://github.com/AtlassianPS/AtlassianPS.Configuration/actions/workflows/ci.yml) |
+| PowerShell 7 on macOS | [CI workflow](https://github.com/AtlassianPS/AtlassianPS.Configuration/actions/workflows/ci.yml) |
+
+## Acknowledgements
+
+* Thanks to everyone ([Our Contributors](https://atlassianps.org/#people)) that helped with this module
 
 ## Useful links
 
@@ -88,7 +108,7 @@ Hopefully this is obvious, but:
   [Latest Release]: https://github.com/AtlassianPS/AtlassianPS.Configuration/releases/latest
   [Submit an Issue]: https://github.com/AtlassianPS/AtlassianPS.Configuration/issues/new
   [MIT license]: https://github.com/AtlassianPS/AtlassianPS.Configuration/blob/master/LICENSE
-  [Contributing]: http://atlassianps.org/docs/Contributing
+  [Contributing]: https://atlassianps.org/docs/Contributing/
 
 <!-- [//]: # (Sweet online markdown editor at http://dillinger.io) -->
 <!-- [//]: # ("GitHub Flavored Markdown" https://help.github.com/articles/github-flavored-markdown/) -->

--- a/docs/en-US/about_AtlassianPS.Configuration.md
+++ b/docs/en-US/about_AtlassianPS.Configuration.md
@@ -74,6 +74,12 @@ Find us on GitHub or Slack, and let us know what you think.
 
 # SEE ALSO
 
+[Commands index](/docs/AtlassianPS.Configuration/commands/)
+
+[Classes index](/docs/AtlassianPS.Configuration/classes/)
+
+[Enumerations index](/docs/AtlassianPS.Configuration/enumerations/)
+
 [AtlassianPS org](https://atlassianps.org)
 
 [AtlassianPS Slack team](https://atlassianps.org/slack)

--- a/docs/en-US/classes/index.md
+++ b/docs/en-US/classes/index.md
@@ -1,0 +1,11 @@
+---
+layout: documentation
+permalink: /docs/AtlassianPS.Configuration/classes/
+hide: true
+---
+# AtlassianPS.Configuration classes
+
+| Class | Documentation |
+|---|---|
+| `AtlassianPS.MessageStyle` | [AtlassianPS.MessageStyle](/docs/AtlassianPS.Configuration/classes/AtlassianPS.MessageStyle/) |
+| `AtlassianPS.ServerData` | [AtlassianPS.ServerData](/docs/AtlassianPS.Configuration/classes/AtlassianPS.ServerData/) |

--- a/docs/en-US/commands/index.md
+++ b/docs/en-US/commands/index.md
@@ -1,0 +1,21 @@
+---
+layout: documentation
+permalink: /docs/AtlassianPS.Configuration/commands/
+hide: true
+---
+# AtlassianPS.Configuration commands
+
+AtlassianPS.Configuration exports these commands with the `Atlassian` default command prefix.
+The documentation pages use the source function names that back the exported commands.
+
+| Exported command | Documentation |
+|---|---|
+| `Add-AtlassianServerConfiguration` | [Add-ServerConfiguration](/docs/AtlassianPS.Configuration/commands/Add-ServerConfiguration/) |
+| `Get-AtlassianConfiguration` | [Get-Configuration](/docs/AtlassianPS.Configuration/commands/Get-Configuration/) |
+| `Get-AtlassianServerConfiguration` | [Get-ServerConfiguration](/docs/AtlassianPS.Configuration/commands/Get-ServerConfiguration/) |
+| `Remove-AtlassianConfiguration` | [Remove-Configuration](/docs/AtlassianPS.Configuration/commands/Remove-Configuration/) |
+| `Remove-AtlassianServerConfiguration` | [Remove-ServerConfiguration](/docs/AtlassianPS.Configuration/commands/Remove-ServerConfiguration/) |
+| `Set-AtlassianConfiguration` | [Set-Configuration](/docs/AtlassianPS.Configuration/commands/Set-Configuration/) |
+| `Set-AtlassianServerConfiguration` | [Set-ServerConfiguration](/docs/AtlassianPS.Configuration/commands/Set-ServerConfiguration/) |
+
+For module overview and setup, see [about_AtlassianPS.Configuration](/docs/AtlassianPS.Configuration/).

--- a/docs/en-US/enumerations/index.md
+++ b/docs/en-US/enumerations/index.md
@@ -1,0 +1,10 @@
+---
+layout: documentation
+permalink: /docs/AtlassianPS.Configuration/enumerations/
+hide: true
+---
+# AtlassianPS.Configuration enumerations
+
+| Enumeration | Documentation |
+|---|---|
+| `AtlassianPS.ServerType` | [AtlassianPS.ServerType](/docs/AtlassianPS.Configuration/enumerations/AtlassianPS.ServerType/) |

--- a/docs/en-US/index.md
+++ b/docs/en-US/index.md
@@ -1,0 +1,12 @@
+---
+layout: documentation
+permalink: /docs/AtlassianPS.Configuration/about/
+hide: true
+---
+# AtlassianPS.Configuration about topics
+
+AtlassianPS.Configuration provides shared server configuration helpers used by AtlassianPS modules.
+
+| Topic | Documentation |
+|---|---|
+| `about_AtlassianPS.Configuration` | [AtlassianPS.Configuration overview](/docs/AtlassianPS.Configuration/) |


### PR DESCRIPTION
## Summary
- add docs root, command, class, and enumeration indexes for website rendering
- link the new indexes from the module about topic
- normalize README examples, links, tested platform table, and acknowledgements

## Validation
- `Invoke-Pester -Path Tests/Help.Tests.ps1` passed: 40 passed, 84 skipped\n- `Invoke-Build -Task Build, Test` passed: 469 passed, 7 skipped