### PR TITLE
docs: fix website navigation links

### DIFF
--- a/docs/en-US/about_AtlassianPS.Configuration.md
+++ b/docs/en-US/about_AtlassianPS.Configuration.md
@@ -33,14 +33,20 @@ Such a key-value pair will not produce any change in behavior of any other
 cmdlet by itself; the module using this module, AtlassianPS.Configuration,
 must implement a usage for the key-value.
 A documentation of the currently implemented key-value pairs can be found in
-[About AtlassianPS.Configuration Keys](about/implemented-keys.html).
+[About AtlassianPS.Configuration Keys](/docs/AtlassianPS.Configuration/about/implemented-keys.html).
+
+## Guides
+
+<div class="reference-index">
+    <a href="/docs/AtlassianPS.Configuration/about/implemented-keys.html">Implemented Keys</a>
+</div>
 
 This module stores the latest configuration in memory to disk.
 By doing so, the module is able to retrieve the last known configuration when
 being imported.
 
 > AtlassianPS.Configuration uses
-> [PoshCode/Configuration](Export-AtlassianConfiguration) for importing and
+> [PoshCode/Configuration](https://github.com/PoshCode/Configuration) for importing and
 > exporting the configuration.  
 > Where the configuration is exported and how the configuration is imported is
 > described [here](https://github.com/PoshCode/Configuration#how-it-works)

--- a/docs/en-US/commands/Add-ServerConfiguration.md
+++ b/docs/en-US/commands/Add-ServerConfiguration.md
@@ -26,7 +26,7 @@ Add-AtlassianServerConfiguration [-Uri] <Uri> [[-Name] <String>]
 This function allows for several Server object to be stored in memory.
 Stored servers are used by the commands in order to know with what server to communicate.
 
-The stored servers can be exported to file with [Export-Configuration](../Export-Configuration/).  
+The stored servers can be exported to file with [Export-Configuration](https://github.com/PoshCode/Configuration).  
 _Exported servers will be imported automatically when the module is loaded._
 
 ## EXAMPLES
@@ -170,4 +170,4 @@ For more information, see about_CommonParameters
 
 [Remove-ServerConfiguration](../Remove-ServerConfiguration/)
 
-[Export-Configuration](../Export-Configuration/)
+[Export-Configuration](https://github.com/PoshCode/Configuration)

--- a/docs/en-US/commands/Get-Configuration.md
+++ b/docs/en-US/commands/Get-Configuration.md
@@ -184,4 +184,4 @@ For more information, see about_CommonParameters
 
 [Remove-Configuration](../Remove-Configuration/)
 
-[Export-Configuration](../Export-Configuration/)
+[Export-Configuration](https://github.com/PoshCode/Configuration)

--- a/docs/en-US/commands/Get-ServerConfiguration.md
+++ b/docs/en-US/commands/Get-ServerConfiguration.md
@@ -125,4 +125,4 @@ For more information, see about_CommonParameters
 
 [Remove-ServerConfiguration](../Remove-ServerConfiguration/)
 
-[Export-Configuration](../Export-Configuration/)
+[Export-Configuration](https://github.com/PoshCode/Configuration)

--- a/docs/en-US/commands/Set-Configuration.md
+++ b/docs/en-US/commands/Set-Configuration.md
@@ -126,4 +126,4 @@ For more information, see about_CommonParameters
 
 [Remove-Configuration](../Remove-Configuration/)
 
-[Export-Configuration](../Export-Configuration/)
+[Export-Configuration](https://github.com/PoshCode/Configuration)

--- a/docs/en-US/commands/Set-ServerConfiguration.md
+++ b/docs/en-US/commands/Set-ServerConfiguration.md
@@ -193,4 +193,4 @@ For more information, see about_CommonParameters
 
 [Remove-ServerConfiguration](../Remove-ServerConfiguration/)
 
-[Export-Configuration](../Export-Configuration/)
+[Export-Configuration](https://github.com/PoshCode/Configuration)


### PR DESCRIPTION
## Summary
- add a website-visible guide section for implemented configuration keys
- fix generated website links to implemented keys and PoshCode/Configuration
- replace stale Export-Configuration related links with the upstream Configuration repository

## Validation
- documentation-only change
- validated through the AtlassianPS.github.io generated-site link audit