### PR TITLE
Recover the v0.2.6 release candidate

### DIFF
--- a/.changelog/38.patch.changed.md
+++ b/.changelog/38.patch.changed.md
@@ -1,0 +1,1 @@
+* Added automatic releases for reviewed contributor pull requests using the exact module artifact validated by CI.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@ee540ecca268608dd5e1957430511ec87f4bc854 # v0.1.14
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@d6a624b73b9d7d4d197340c960fee647c0d215d7 # v0.1.15
 
       - run: Invoke-Build -Task Lint, Build
         shell: pwsh
@@ -56,7 +56,7 @@ jobs:
             "tag=$($Matches.tag)" >> $env:GITHUB_OUTPUT
           }
 
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/build-release-notes@ee540ecca268608dd5e1957430511ec87f4bc854 # v0.1.14
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/build-release-notes@d6a624b73b9d7d4d197340c960fee647c0d215d7 # v0.1.15
         if: steps.release.outputs.tag != ''
         with:
           release-version: ${{ steps.release.outputs.tag }}
@@ -81,7 +81,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@ee540ecca268608dd5e1957430511ec87f4bc854 # v0.1.14
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@d6a624b73b9d7d4d197340c960fee647c0d215d7 # v0.1.15
         with:
           ps-version: "5"
           # Setup is run below in the powershell (PS 5.1) shell instead of pwsh,
@@ -121,7 +121,7 @@ jobs:
           - { os: macos-latest, name: "macOS" }
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@ee540ecca268608dd5e1957430511ec87f4bc854 # v0.1.14
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@d6a624b73b9d7d4d197340c960fee647c0d215d7 # v0.1.15
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/continuous_release.yml
+++ b/.github/workflows/continuous_release.yml
@@ -42,18 +42,18 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.workflow_run.head_sha || 'master' }}
 
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/plan-merged-release@ee540ecca268608dd5e1957430511ec87f4bc854 # v0.1.14
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/plan-merged-release@d6a624b73b9d7d4d197340c960fee647c0d215d7 # v0.1.15
         id: plan
         with:
           commit-sha: ${{ github.event.workflow_run.head_sha }}
           release-impact: ${{ inputs.release_impact }}
 
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/prepare-release-changelog@ee540ecca268608dd5e1957430511ec87f4bc854 # v0.1.14
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/prepare-release-changelog@d6a624b73b9d7d4d197340c960fee647c0d215d7 # v0.1.15
         if: steps.plan.outputs.should_release == 'true'
         with:
           release-version: ${{ steps.plan.outputs.release_tag }}
 
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@ee540ecca268608dd5e1957430511ec87f4bc854 # v0.1.14
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@d6a624b73b9d7d4d197340c960fee647c0d215d7 # v0.1.15
         if: steps.plan.outputs.should_release == 'true'
 
       - name: Stamp source manifest version
@@ -71,7 +71,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: AtlassianPS.Configuration
 
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/commit-release-metadata@ee540ecca268608dd5e1957430511ec87f4bc854 # v0.1.14
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/commit-release-metadata@d6a624b73b9d7d4d197340c960fee647c0d215d7 # v0.1.15
         if: steps.plan.outputs.should_release == 'true'
         with:
           release-tag: ${{ steps.plan.outputs.release_tag }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@ee540ecca268608dd5e1957430511ec87f4bc854 # v0.1.14
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@d6a624b73b9d7d4d197340c960fee647c0d215d7 # v0.1.15

--- a/.github/workflows/release_intent.yml
+++ b/.github/workflows/release_intent.yml
@@ -13,4 +13,4 @@ jobs:
     name: Release Intent
     runs-on: ubuntu-latest
     steps:
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/validate-release-intent@ee540ecca268608dd5e1957430511ec87f4bc854 # v0.1.14
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/validate-release-intent@d6a624b73b9d7d4d197340c960fee647c0d215d7 # v0.1.15

--- a/AtlassianPS.Configuration.build.ps1
+++ b/AtlassianPS.Configuration.build.ps1
@@ -1,5 +1,5 @@
 ﻿#requires -modules InvokeBuild
-#requires -modules @{ ModuleName = 'AtlassianPS.Standards'; ModuleVersion = '0.1.14'; MaximumVersion = '0.1.14' }
+#requires -modules @{ ModuleName = 'AtlassianPS.Standards'; ModuleVersion = '0.1.15'; MaximumVersion = '0.1.15' }
 
 [CmdletBinding()]
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingWriteHost', '')]

--- a/AtlassianPS.Configuration/AtlassianPS.Configuration.psd1
+++ b/AtlassianPS.Configuration/AtlassianPS.Configuration.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     RootModule           = 'AtlassianPS.Configuration.psm1'
-    ModuleVersion        = '0.2.6'
+    ModuleVersion        = '0.2'
     GUID                 = 'f946e1f7-ed4f-43da-aa24-6d57a25117cb'
     Author               = 'Lipkau'
     CompanyName          = 'AtlassianPS'
@@ -9,7 +9,7 @@
     RequiredModules      = @(
         @{
             ModuleName    = 'Configuration'
-            ModuleVersion = '0.2.6'
+            ModuleVersion = '1.3.1'
         }
     )
     FormatsToProcess     = @('AtlassianPS.Configuration.format.ps1xml')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-## v0.2.6 - 2026-08-21
-
 ### Improvements
 
 - Added `-WhatIf` and `-Confirm` support to mutating configuration and server configuration commands.
 - Migrated `Tools/setup.ps1` to shared `AtlassianPS.Standards` bootstrap/dependency commands with synchronized ScriptAnalyzer settings.
 - Migrated `Tools/update.dependencies.ps1` to shared `AtlassianPS.Standards\Update-AtlassianPSDependencyReference` with `ShouldProcess` and fail-fast behavior.
-- Aligned workflow and build dependencies with `AtlassianPS.Standards` `0.1.14`.
+- Aligned workflow and build dependencies with `AtlassianPS.Standards` `0.1.15`.
 - Added regression coverage for setup/update delegation and cross-surface standards version consistency.
 - Aligned release artifact creation and validation with shared `AtlassianPS.Standards` helpers.
 - Made `CHANGELOG.md` the release-notes source for both PSGallery metadata and GitHub releases.
@@ -33,7 +31,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed server add/remove/update edge cases around duplicate names, pipeline input, URI validation, and empty server lists.
 - Protected the internal `ServerList` key from generic configuration mutation while keeping `Message` configurable.
 - Corrected first-use and command documentation for server configuration commands.
-* Added automatic releases for reviewed contributor pull requests using the exact module artifact validated by CI.
 
 ## v0.2.5 - 2019-03-06
 

--- a/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
+++ b/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
@@ -4,7 +4,7 @@ Describe 'AtlassianPS.Standards version consistency' -Tag Unit {
     BeforeAll {
         . "$PSScriptRoot/../Helpers/TestTools.ps1"
         $script:projectRoot = Resolve-ProjectRoot
-        $script:standardsActionSha = 'ee540ecca268608dd5e1957430511ec87f4bc854'
+        $script:standardsActionSha = 'd6a624b73b9d7d4d197340c960fee647c0d215d7'
 
         $requirementsPath = Join-Path $script:projectRoot 'Tools/build.requirements.psd1'
         $requirements = Import-PowerShellDataFile -Path $requirementsPath

--- a/Tools/build.requirements.psd1
+++ b/Tools/build.requirements.psd1
@@ -1,5 +1,5 @@
 ﻿@(
-    @{ ModuleName = "AtlassianPS.Standards"; RequiredVersion = "0.1.14" }
+    @{ ModuleName = "AtlassianPS.Standards"; RequiredVersion = "0.1.15" }
     @{ ModuleName = "InvokeBuild"; RequiredVersion = "5.14.23" }
     @{ ModuleName = "Metadata"; RequiredVersion = "1.5.7" }
     @{ ModuleName = "Configuration"; RequiredVersion = "1.3.1" }


### PR DESCRIPTION
## Summary

- restore the unreleased changelog state after the failed candidate build
- consume AtlassianPS.Standards 0.1.15, which preserves nested dependency versions during manifest stamping
- keep the Configuration dependency pinned to 1.3.1 while stamping the module itself to 0.2.6
- carry the v0.2.6 release intent after PR #30 was relabeled release:none for clean recovery validation

## Validation

- actionlint passed
- full Lint, Build, Test gate passed: 950 passed, 19 skipped
- direct 0.2.6 stamp proof: module 0.2.6, dependency 1.3.1

No v0.2.6 tag or package was published by the failed run.