### PR TITLE
Install module dependencies before publishing

### DIFF
--- a/.changelog/39.patch.fixed.md
+++ b/.changelog/39.patch.fixed.md
@@ -1,0 +1,1 @@
+* Fixed automatic publishing to install the tested module's declared dependencies before calling `Publish-Module`. `v0.2.6` was not published; its changes are included in this release.

--- a/.github/workflows/continuous_release.yml
+++ b/.github/workflows/continuous_release.yml
@@ -161,6 +161,12 @@ jobs:
             Write-Host "PSGallery already contains AtlassianPS.Configuration $expectedGalleryVersion; skipping immutable publish."
             return
           }
+
+          $manifest = Import-PowerShellDataFile ./Release/AtlassianPS.Configuration/AtlassianPS.Configuration.psd1
+          foreach ($dependency in @($manifest.RequiredModules)) {
+            Install-Module -Name $dependency.ModuleName -MinimumVersion $dependency.ModuleVersion -Repository PSGallery -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop
+          }
+
           Publish-Module -Path ./Release/AtlassianPS.Configuration -Repository PSGallery -NuGetApiKey ${{ secrets.PSGALLERY_API_KEY }} -ErrorAction Stop
         shell: pwsh
 

--- a/Tests/GitHubActions.Unit.Tests.ps1
+++ b/Tests/GitHubActions.Unit.Tests.ps1
@@ -46,10 +46,12 @@ Describe 'GitHub Actions release contract' -Tag Unit {
         $publishJob | Should -Not -Match 'actions/checkout@|uses:\s+\./|Invoke-Build'
 
         $tagIndex = $publishJob.IndexOf('Create annotated release tag')
+        $dependencyIndex = $publishJob.IndexOf('Install-Module -Name $dependency.ModuleName')
         $publishIndex = $publishJob.IndexOf('Publish-Module -Path ./Release/AtlassianPS.Configuration')
         $releaseIndex = $publishJob.IndexOf('softprops/action-gh-release')
         $tagIndex | Should -BeGreaterOrEqual 0
-        $publishIndex | Should -BeGreaterThan $tagIndex
+        $dependencyIndex | Should -BeGreaterThan $tagIndex
+        $publishIndex | Should -BeGreaterThan $dependencyIndex
         $releaseIndex | Should -BeGreaterThan $publishIndex
     }
 


### PR DESCRIPTION
## Summary

- install RequiredModules from the tested artifact before calling Publish-Module
- preserve artifact-only promotion with no checkout or rebuild
- enforce the dependency-install-before-publish ordering in contract tests

## Validation

- actionlint passed
- focused workflow tests: 8 passed
- full Lint, Build, Test gate: 950 passed, 19 skipped

v0.2.6 remains skipped; this patch will publish as v0.2.7.