### PR TITLE
Clarify copyright attribution

### DIFF
--- a/AtlassianPS.Configuration/AtlassianPS.Configuration.psd1
+++ b/AtlassianPS.Configuration/AtlassianPS.Configuration.psd1
@@ -4,7 +4,7 @@
     GUID                 = 'f946e1f7-ed4f-43da-aa24-6d57a25117cb'
     Author               = 'Lipkau'
     CompanyName          = 'AtlassianPS'
-    Copyright            = '(c) 2018 AtlassianPS. All rights reserved.'
+    Copyright            = '(c) 2018 AtlassianPS contributors.'
     Description          = "A module for modules - AtlasianPS modules use this to handle the user's configuration"
     RequiredModules      = @(
         @{

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 AtlassianPS
+Copyright (c) 2018 AtlassianPS contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Tests/Project.Tests.ps1
+++ b/Tests/Project.Tests.ps1
@@ -114,7 +114,7 @@ Describe "General project validation" -Tag Unit {
         It "uses the MIT license" {
             Test-Path "$env:BHProjectPath/LICENSE" | Should -BeTrue
             "$env:BHProjectPath/LICENSE" | Should -FileContentMatchExactly "MIT License"
-            "$env:BHProjectPath/LICENSE" | Should -FileContentMatch "Copyright \(c\) 20\d{2} AtlassianPS"
+            "$env:BHProjectPath/LICENSE" | Should -FileContentMatch "Copyright \(c\) 20\d{2} AtlassianPS contributors"
         }
 
         It "has a .gitignore" {


### PR DESCRIPTION
## Summary

- attribute first-party work to `AtlassianPS contributors`
- align the module manifest with the 2018 MIT license notice
- remove the misleading `All rights reserved` wording from MIT-licensed metadata
- update the project test for the standardized notice

This changes attribution metadata, not the MIT license terms.

## Validation

- `Test-ModuleManifest`
- `Invoke-Build -Task Lint`
- `Invoke-Build -Task Build, Test` — 950 passed, 19 skipped
