### PR TITLE
test: standardize on Pester 5.9

### DIFF
--- a/.changelog/42.patch.changed.md
+++ b/.changelog/42.patch.changed.md
@@ -1,0 +1,1 @@
+* Standardized lint and unit test execution on Pester 5.9.x, using 5.9.0 as the clean-install baseline and 5.9.999 as the upper compatibility bound (#42, @lipkau).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@3c050eda17bfb4177f93c3cac61610a6f21b2537 # v0.1.16
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@fc574a6647971312d28383dd06e29a1a8d2e66e6 # v0.1.18
 
       - run: Invoke-Build -Task Lint, Build
         shell: pwsh
@@ -56,7 +56,7 @@ jobs:
             "tag=$($Matches.tag)" >> $env:GITHUB_OUTPUT
           }
 
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/build-release-notes@3c050eda17bfb4177f93c3cac61610a6f21b2537 # v0.1.16
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/build-release-notes@fc574a6647971312d28383dd06e29a1a8d2e66e6 # v0.1.18
         if: steps.release.outputs.tag != ''
         with:
           release-version: ${{ steps.release.outputs.tag }}
@@ -81,7 +81,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@3c050eda17bfb4177f93c3cac61610a6f21b2537 # v0.1.16
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@fc574a6647971312d28383dd06e29a1a8d2e66e6 # v0.1.18
         with:
           ps-version: "5"
           # Setup is run below in the powershell (PS 5.1) shell instead of pwsh,
@@ -121,7 +121,7 @@ jobs:
           - { os: macos-latest, name: "macOS" }
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@3c050eda17bfb4177f93c3cac61610a6f21b2537 # v0.1.16
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@fc574a6647971312d28383dd06e29a1a8d2e66e6 # v0.1.18
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/continuous_release.yml
+++ b/.github/workflows/continuous_release.yml
@@ -18,11 +18,12 @@ on:
 permissions:
   actions: read
   contents: read
+  issues: read
   pull-requests: read
 
 jobs:
   release:
-    uses: AtlassianPS/AtlassianPS.Standards/.github/workflows/module_release.yml@3c050eda17bfb4177f93c3cac61610a6f21b2537 # v0.1.16
+    uses: AtlassianPS/AtlassianPS.Standards/.github/workflows/module_release.yml@fc574a6647971312d28383dd06e29a1a8d2e66e6 # v0.1.18
     with:
       module-name: AtlassianPS.Configuration
       release-impact: ${{ inputs.release_impact }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@3c050eda17bfb4177f93c3cac61610a6f21b2537 # v0.1.16
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@fc574a6647971312d28383dd06e29a1a8d2e66e6 # v0.1.18

--- a/.github/workflows/release_intent.yml
+++ b/.github/workflows/release_intent.yml
@@ -13,4 +13,4 @@ jobs:
     name: Release Intent
     runs-on: ubuntu-latest
     steps:
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/validate-release-intent@3c050eda17bfb4177f93c3cac61610a6f21b2537 # v0.1.16
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/validate-release-intent@fc574a6647971312d28383dd06e29a1a8d2e66e6 # v0.1.18

--- a/AtlassianPS.Configuration.build.ps1
+++ b/AtlassianPS.Configuration.build.ps1
@@ -150,15 +150,37 @@ task Lint {
         "$env:BHProjectPath/$env:BHProjectName.build.ps1"
     )
 
-    $null = Invoke-AtlassianPSLint `
-        -ProjectPath $env:BHProjectPath `
-        -ModulePath $env:BHModulePath `
-        -BuildScriptPath "$env:BHProjectPath/$env:BHProjectName.build.ps1" `
-        -StyleTestPath "$env:BHProjectPath/Tests/Style.Tests.ps1" `
-        -AnalyzerSettingsPath "$env:BHProjectPath/PSScriptAnalyzerSettings.psd1" `
-        -AnalyzerPaths $analyzerPaths `
-        -PesterVerbosity $PesterVerbosity `
-        -Severity @('Error', 'Warning')
+    $lintFailures = @()
+    try {
+        $null = Invoke-AtlassianPSModuleTests `
+            -TestPath "$env:BHProjectPath/Tests/Style.Tests.ps1" `
+            -PesterVerbosity $PesterVerbosity `
+            -MinimumPesterVersion ([Version]'5.9.0') `
+            -MaximumPesterVersion ([Version]'5.9.999')
+    }
+    catch {
+        $lintFailures += $_.Exception.Message
+    }
+
+    try {
+        $null = Invoke-AtlassianPSLint `
+            -ProjectPath $env:BHProjectPath `
+            -ModulePath $env:BHModulePath `
+            -BuildScriptPath "$env:BHProjectPath/$env:BHProjectName.build.ps1" `
+            -StyleTestPath "$env:BHProjectPath/Tests/Style.Tests.ps1" `
+            -AnalyzerSettingsPath "$env:BHProjectPath/PSScriptAnalyzerSettings.psd1" `
+            -AnalyzerPaths $analyzerPaths `
+            -PesterVerbosity $PesterVerbosity `
+            -Severity @('Error', 'Warning') `
+            -SkipStyleTests
+    }
+    catch {
+        $lintFailures += $_.Exception.Message
+    }
+
+    if ($lintFailures.Count -gt 0) {
+        throw ("Lint failed:`n  - " + ($lintFailures -join "`n  - "))
+    }
 }
 
 #region BuildRelease
@@ -514,6 +536,8 @@ task Test Init, {
     Assert-True { Test-Path $env:BHBuildOutput -PathType Container } "Release path must exist"
 
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
+    Get-Module Pester | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module Pester -MinimumVersion '5.9.0' -MaximumVersion '5.9.999' -Force -ErrorAction Stop
 
     <# $params = @{
         Path    = "$env:BHBuildOutput/$env:BHProjectName"

--- a/AtlassianPS.Configuration.build.ps1
+++ b/AtlassianPS.Configuration.build.ps1
@@ -1,5 +1,5 @@
 ﻿#requires -modules InvokeBuild
-#requires -modules @{ ModuleName = 'AtlassianPS.Standards'; ModuleVersion = '0.1.16'; MaximumVersion = '0.1.16' }
+#requires -modules @{ ModuleName = 'AtlassianPS.Standards'; ModuleVersion = '0.1.18'; MaximumVersion = '0.1.18' }
 
 [CmdletBinding()]
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingWriteHost', '')]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Standardized lint and unit test execution on Pester 5.9.x, using 5.9.0 as the clean-install baseline and 5.9.999 as the upper compatibility bound.
+
 ## v0.2.8 - 2026-08-24
 
 * Delegate releases to Standards (#41, @lipkau)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-* Standardized lint and unit test execution on Pester 5.9.x, using 5.9.0 as the clean-install baseline and 5.9.999 as the upper compatibility bound.
-
 ## v0.2.8 - 2026-08-24
 
 * Delegate releases to Standards (#41, @lipkau)

--- a/Tests/AtlassianPS.Configuration.Tests.ps1
+++ b/Tests/AtlassianPS.Configuration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "General project validation" -Tag Build {
     BeforeAll {

--- a/Tests/Build.Tests.ps1
+++ b/Tests/Build.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Validation of build environment" -Tag Unit {
     BeforeAll {

--- a/Tests/Classes/AtlassianPS.MessageStyle.Unit.Tests.ps1
+++ b/Tests/Classes/AtlassianPS.MessageStyle.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "[AtlassianPS.MessageStyle] Tests" -Tag Unit {
     BeforeAll {

--- a/Tests/Classes/AtlassianPS.ServerData.Unit.Tests.ps1
+++ b/Tests/Classes/AtlassianPS.ServerData.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "[AtlassianPS.ServerData] Tests" -Tag Unit {
     BeforeAll {

--- a/Tests/Enumerations/AtlassianPS.ServerType.Unit.Tests.ps1
+++ b/Tests/Enumerations/AtlassianPS.ServerType.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "[AtlassianPS.ServerType] Tests" -Tag Unit {
 

--- a/Tests/Examples.Tests.ps1
+++ b/Tests/Examples.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/Helpers/TestTools.ps1"

--- a/Tests/Functions/.template.ps1
+++ b/Tests/Functions/.template.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 <#
 .SYNOPSIS

--- a/Tests/Functions/Add-ServerConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Add-ServerConfiguration.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Add-ServerConfiguration" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/ConvertFrom-QueryString.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertFrom-QueryString.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "ConvertFrom-QueryString" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/ConvertFrom-URLEncoded.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertFrom-URLEncoded.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "ConvertFrom-URLEncoded" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/ConvertTo-Hashtable.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-Hashtable.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "ConvertTo-Hashtable" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/ConvertTo-QueryString.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-QueryString.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "ConvertTo-QueryString" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/ConvertTo-URLEncoded.Unit.Tests.ps1
+++ b/Tests/Functions/ConvertTo-URLEncoded.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "ConvertTo-URLEncoded" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Format-MessageStyle.Unit.Tests.ps1
+++ b/Tests/Functions/Format-MessageStyle.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Format-MessageStyle" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Get-BreadCrumb.Unit.Tests.ps1
+++ b/Tests/Functions/Get-BreadCrumb.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Get-BreadCrumb" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Get-Configuration.Unit.Tests.ps1
+++ b/Tests/Functions/Get-Configuration.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Get-Configuration" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Get-ServerConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Get-ServerConfiguration.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Get-ServerConfiguration" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Import-HttpUtility.Unit.Tests.ps1
+++ b/Tests/Functions/Import-HttpUtility.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Import-HttpUtility" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Import-MqcnAlias.Unit.Tests.ps1
+++ b/Tests/Functions/Import-MqcnAlias.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Import-MqcnAlias" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Invoke-WebRequest.Unit.Tests.ps1
+++ b/Tests/Functions/Invoke-WebRequest.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Invoke-WebRequest" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Join-Hashtable.Unit.Tests.ps1
+++ b/Tests/Functions/Join-Hashtable.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Join-Hashtable" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/New-ErrorRecord.Unit.Tests.ps1
+++ b/Tests/Functions/New-ErrorRecord.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "New-ErrorRecord" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Remove-Configuration.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-Configuration.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Remove-Configuration" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Remove-ServerConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Remove-ServerConfiguration.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Remove-ServerConfiguration" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Resolve-DefaultParameterValue.Unit.Tests.ps1
+++ b/Tests/Functions/Resolve-DefaultParameterValue.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Resolve-DefaultParameterValue" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Resolve-FilePath.Unit.Tests.ps1
+++ b/Tests/Functions/Resolve-FilePath.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Resolve-FilePath" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Resolve-FullPath.Unit.Tests.ps1
+++ b/Tests/Functions/Resolve-FullPath.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Resolve-FullPath" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Save-Configuration.Unit.Tests.ps1
+++ b/Tests/Functions/Save-Configuration.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Save-Configuration" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Set-Configuration.Unit.Tests.ps1
+++ b/Tests/Functions/Set-Configuration.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Set-Configuration" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Set-ServerConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Set-ServerConfiguration.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Set-ServerConfiguration" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/ThrowError.Unit.Tests.ps1
+++ b/Tests/Functions/ThrowError.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "ThrowError" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Write-DebugMessage.Unit.Tests.ps1
+++ b/Tests/Functions/Write-DebugMessage.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Write-DebugMessage" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Write-NonTerminatingError.Unit.Tests.ps1
+++ b/Tests/Functions/Write-NonTerminatingError.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Write-NonTerminatingError" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Write-TerminatingError.Unit.Tests.ps1
+++ b/Tests/Functions/Write-TerminatingError.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Write-TerminatingError" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Write-Verbose.Unit.Tests.ps1
+++ b/Tests/Functions/Write-Verbose.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Write-Verbose" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/Write-VerboseMessage.Unit.Tests.ps1
+++ b/Tests/Functions/Write-VerboseMessage.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Write-VerboseMessage" -Tag Unit {
     BeforeAll {

--- a/Tests/Functions/WriteError.Unit.Tests.ps1
+++ b/Tests/Functions/WriteError.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "WriteError" -Tag Unit {
     BeforeAll {

--- a/Tests/GitHubActions.Unit.Tests.ps1
+++ b/Tests/GitHubActions.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe 'GitHub Actions release contract' -Tag Unit {
     BeforeAll {

--- a/Tests/Help.Tests.ps1
+++ b/Tests/Help.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/Helpers/TestTools.ps1"

--- a/Tests/PSScriptAnalyzer.Tests.ps1
+++ b/Tests/PSScriptAnalyzer.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 #requires -modules @{ ModuleName = 'PSScriptAnalyzer'; ModuleVersion = '1.25.0' }
 
 Describe "PSScriptAnalyzer Tests" -Tag Build {

--- a/Tests/Project.Tests.ps1
+++ b/Tests/Project.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/Helpers/TestTools.ps1"
@@ -65,7 +65,11 @@ Describe "General project validation" -Tag Unit {
             }
 
             It "is loaded in the module" {
-                $commandInModule = $module.Invoke({ Get-Command -Name $args[0] -ErrorAction SilentlyContinue }, $functionName)
+                $commandInModule = InModuleScope AtlassianPS.Configuration -Parameters @{ Name = $functionName } {
+                    param($Name)
+
+                    Get-Command -Name $Name -CommandType Function -ErrorAction SilentlyContinue
+                }
                 $commandInModule | Should -Not -BeNullOrEmpty -Because "private function '$functionName' should be loaded"
             }
 

--- a/Tests/Style.Tests.ps1
+++ b/Tests/Style.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe "Style rules" -Tag "Unit" {
     BeforeAll {

--- a/Tests/TestTools.Tests.ps1
+++ b/Tests/TestTools.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe 'Initialize-TestEnvironment' -Tag Unit {
     BeforeAll {

--- a/Tests/Tools/SetupScript.Unit.Tests.ps1
+++ b/Tests/Tools/SetupScript.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe 'Tools/setup.ps1' -Tag Unit {
     BeforeAll {

--- a/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
+++ b/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe 'AtlassianPS.Standards version consistency' -Tag Unit {
     BeforeAll {

--- a/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
+++ b/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
@@ -4,7 +4,7 @@ Describe 'AtlassianPS.Standards version consistency' -Tag Unit {
     BeforeAll {
         . "$PSScriptRoot/../Helpers/TestTools.ps1"
         $script:projectRoot = Resolve-ProjectRoot
-        $script:standardsActionSha = '3c050eda17bfb4177f93c3cac61610a6f21b2537'
+        $script:standardsActionSha = 'fc574a6647971312d28383dd06e29a1a8d2e66e6'
 
         $requirementsPath = Join-Path $script:projectRoot 'Tools/build.requirements.psd1'
         $requirements = Import-PowerShellDataFile -Path $requirementsPath
@@ -29,6 +29,13 @@ Describe 'AtlassianPS.Standards version consistency' -Tag Unit {
             Should -Be @($script:standardsActionSha)
         @($matches | ForEach-Object { $_.Groups['version'].Value } | Select-Object -Unique) |
             Should -Be @($script:standardsVersion)
+    }
+
+    It 'grants the shared release workflow issue read access' {
+        $workflow = Get-Content (Join-Path $script:projectRoot '.github/workflows/continuous_release.yml') -Raw
+
+        $workflow | Should -Match 'issues:\s+read'
+        $workflow | Should -Match 'workflows/module_release\.yml@[0-9a-f]{40}'
     }
 
     It 'keeps the build script requirement aligned with build.requirements' {

--- a/Tests/Tools/UpdateDependenciesScript.Unit.Tests.ps1
+++ b/Tests/Tools/UpdateDependenciesScript.Unit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.9.0"; MaximumVersion = "5.9.999" }
 
 Describe 'Tools/update.dependencies.ps1' -Tag Unit {
     BeforeAll {

--- a/Tools/build.requirements.psd1
+++ b/Tools/build.requirements.psd1
@@ -1,5 +1,5 @@
 ﻿@(
-    @{ ModuleName = "AtlassianPS.Standards"; RequiredVersion = "0.1.16" }
+    @{ ModuleName = "AtlassianPS.Standards"; RequiredVersion = "0.1.18" }
     @{ ModuleName = "InvokeBuild"; RequiredVersion = "5.14.23" }
     @{ ModuleName = "Metadata"; RequiredVersion = "1.5.7" }
     @{ ModuleName = "Configuration"; RequiredVersion = "1.3.1" }

--- a/Tools/build.requirements.psd1
+++ b/Tools/build.requirements.psd1
@@ -3,7 +3,7 @@
     @{ ModuleName = "InvokeBuild"; RequiredVersion = "5.14.23" }
     @{ ModuleName = "Metadata"; RequiredVersion = "1.5.7" }
     @{ ModuleName = "Configuration"; RequiredVersion = "1.3.1" }
-    @{ ModuleName = "Pester"; RequiredVersion = "5.7.1" }
+    @{ ModuleName = "Pester"; RequiredVersion = "5.9.0" }
     @{ ModuleName = "Microsoft.PowerShell.PlatyPS"; RequiredVersion = "1.0.1" }
     @{ ModuleName = "PSScriptAnalyzer"; RequiredVersion = "1.25.0" }
 )


### PR DESCRIPTION
## Summary

- Standardize lint and unit tests on Pester 5.9.x.
- Use Pester 5.9.0 for clean dependency installations.
- Cap supported Pester versions at 5.9.999.
- Update the release workflow and local tooling to AtlassianPS.Standards v0.1.18.
- Move the public change note into `.changelog/42.patch.changed.md`.

## Why

Pester 5.9.0 gives clean environments a reproducible baseline while still allowing compatible 5.9.x updates. Standards v0.1.18 adds the current continuous-release fixes, including issue-label access and fragment-based changelog generation.

## Validation

- `actionlint .github/workflows/*.yml`
- Standards consistency tests: 4 passed
- `Invoke-Build -Task Build, Test`: 949 passed, 19 skipped
- CI passed on Windows PowerShell 5.1, PowerShell 7, Ubuntu, and macOS
- Release Intent passed with `release:patch` and the changelog fragment

## Release

After merge, the shared pipeline should publish `v0.2.9` from the exact CI-tested artifact.
