### PR TITLE
Limit Continuous Release to master CI runs

### DIFF
--- a/.github/workflows/continuous_release.yml
+++ b/.github/workflows/continuous_release.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: [CI]
     types: [completed]
+    branches: [master]
   workflow_dispatch:
     inputs:
       release_impact:

--- a/Tests/GitHubActions.Unit.Tests.ps1
+++ b/Tests/GitHubActions.Unit.Tests.ps1
@@ -36,6 +36,7 @@ Describe 'GitHub Actions release contract' -Tag Unit {
     }
 
     It 'delegates release orchestration to the immutable Standards workflow' {
+        $script:continuousRelease | Should -Match '(?ms)workflow_run:.*?branches:\s*\[master\]'
         $script:continuousRelease | Should -Match 'uses:\s+AtlassianPS/AtlassianPS\.Standards/\.github/workflows/module_release\.yml@[0-9a-f]{40}'
         $script:continuousRelease | Should -Match 'module-name:\s+AtlassianPS\.Configuration'
         $script:continuousRelease | Should -Match 'release-impact:\s+\$\{\{\s*inputs\.release_impact\s*\}\}'


### PR DESCRIPTION
## Summary

- Filter the Continuous Release workflow_run trigger to master.
- Keep manual release dispatch unchanged.
- Add a workflow-contract assertion.

## Why

Pull-request CI completions currently create skipped Continuous Release runs. Filtering at the trigger removes that workflow noise while preserving the release path for successful master CI.

## Validation

- actionlint passed.
- GitHub Actions contract tests: 7 passed.
- Full build/test reached 945 passing tests; 5 existing generated-help parameter-type checks failed.

## Related pull requests

- AtlassianPS.Configuration: https://github.com/AtlassianPS/AtlassianPS.Configuration/pull/45
- AtlassianPS.Standards: https://github.com/AtlassianPS/AtlassianPS.Standards/pull/56
- ConfluencePS: https://github.com/AtlassianPS/ConfluencePS/pull/264
- JiraAgilePS: https://github.com/AtlassianPS/JiraAgilePS/pull/49
- JiraPS: https://github.com/AtlassianPS/JiraPS/pull/711