### PR TITLE
Reduce release-intent workflow runs

### DIFF
--- a/.github/workflows/release_intent.yml
+++ b/.github/workflows/release_intent.yml
@@ -2,7 +2,7 @@ name: Release Intent
 
 on:
   pull_request_target:
-    types: [opened, edited, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
   pull-requests: read

--- a/Tests/GitHubActions.Unit.Tests.ps1
+++ b/Tests/GitHubActions.Unit.Tests.ps1
@@ -23,6 +23,10 @@ Describe 'GitHub Actions release contract' -Tag Unit {
 
     It 'validates release intent using only the immutable remote action' {
         $script:releaseIntent | Should -Match '(?m)^\s+pull_request_target:'
+        $script:releaseIntent | Should -Not -Match '(?m)types:\s*\[[^\]]*\bedited\b'
+        $script:releaseIntent | Should -Match '(?m)types:\s*\[[^\]]*\bsynchronize\b'
+        $script:releaseIntent | Should -Match '(?m)types:\s*\[[^\]]*\blabeled\b'
+        $script:releaseIntent | Should -Match '(?m)types:\s*\[[^\]]*\bunlabeled\b'
         $script:releaseIntent | Should -Match 'AtlassianPS/AtlassianPS\.Standards/\.github/actions/validate-release-intent@'
         $script:releaseIntent | Should -Match '(?m)^\s+pull-requests:\s+read\r?$'
         $script:releaseIntent | Should -Match '(?m)^\s+issues:\s+write\r?$'


### PR DESCRIPTION
## Summary

- stop rerunning release-intent validation for PR title or body edits
- preserve synchronization and label-change validation triggers
- add regression coverage for the trigger contract

## Validation

- actionlint
- focused GitHub Actions tests: 7 passed
- full build reached 945 passing tests; 5 existing help-metadata tests failed independently of this workflow-only change

## Related pull requests

- AtlassianPS.Configuration #46
- AtlassianPS.Standards #57
- AtlassianPS.github.io #61
- ConfluencePS #265
- JiraAgilePS #50
- JiraPS #713