### PR TITLE
Document pull request release intent

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,14 @@
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
+### Release intent
+
+<!-- Maintainers apply exactly one release label: release:none, release:patch, release:minor, or release:major. -->
+<!-- A releasing PR also needs one changelog:* label or one .changelog/<pr>.<impact>.<type>.md fragment. -->
+
+- [ ] This change needs no independent package release (`release:none`).
+- [ ] This change needs a patch, minor, or major release and includes release-note intent.
+
 ### Checklist
 
 <!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,3 +66,4 @@ Invoke-Pester -Path 'Tests/Functions/Get-Configuration.Unit.Tests.ps1'
 - Instruction-only changes can be skipped by CI path filters; run local validation and report exact command outcomes.
 - `.github/workflows/release_intent.yml` validates one `release:*` intent per pull request.
 - `.github/workflows/continuous_release.yml` prepares and publishes the exact candidate validated by CI.
+- Branch protection requires both `CI Result` and `Release Intent` before merge.


### PR DESCRIPTION
## Summary

- explain release and changelog intent in the pull request template
- record the required Release Intent branch-protection check

## Validation

- Invoke-Build -Task Build, Test (945 passed; 5 pre-existing generated-help metadata failures)
- git diff --check