### PR TITLE
Fix dependency setup delegation

### DIFF
--- a/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
+++ b/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
@@ -50,6 +50,8 @@ Describe 'AtlassianPS.Standards version consistency' -Tag Unit {
 
         $setupScript | Should -Match '\$buildRequirements\s*=\s*Import-PowerShellDataFile'
         $setupScript | Should -Match '-RequiredVersion\s+\$standardsVersion'
+        $setupScript | Should -Match 'Install-AtlassianPSDependencyRequirement'
+        $setupScript | Should -Not -Match "Install-Module -Name 'Configuration'"
     }
 
     It 'loads the pinned Pester version before running the test task' {

--- a/Tools/setup.ps1
+++ b/Tools/setup.ps1
@@ -73,28 +73,6 @@ Install-Module -Name 'AtlassianPS.Standards' `
 
 Import-Module -Name 'AtlassianPS.Standards' -RequiredVersion $standardsVersion -Force -ErrorAction Stop
 
-$manifestData = Import-PowerShellDataFile -Path $manifestPath
-$manifestRequirements = @($manifestData.RequiredModules)
-$configurationRequirement = $manifestRequirements |
-    Where-Object { $_.ModuleName -eq 'Configuration' } |
-    Select-Object -First 1
-if ($configurationRequirement) {
-    $configurationVersion = [Version]$configurationRequirement.RequiredVersion
-    $installedConfiguration = Get-Module -Name 'Configuration' -ListAvailable |
-        Where-Object Version -EQ $configurationVersion |
-        Select-Object -First 1
-    if (-not $installedConfiguration) {
-        Install-Module -Name 'Configuration' `
-            -RequiredVersion $configurationVersion `
-            -Scope CurrentUser `
-            -Repository 'PSGallery' `
-            -SkipPublisherCheck `
-            -AllowClobber `
-            -Force `
-            -ErrorAction Stop
-    }
-}
-
 $null = Install-AtlassianPSDependencyRequirement `
     -BuildRequirementsPath $buildRequirementsPath `
     -ManifestPath $manifestPath `


### PR DESCRIPTION
## Summary

- remove the redundant direct Configuration-module bootstrap added by #43
- delegate all manifest and build dependency installation to AtlassianPS.Standards
- add contract coverage preventing a second Configuration-specific install path

The shared installer already handles manifest dependencies, including the required publisher-check behavior. Keeping a second path duplicated policy and read the wrong manifest version property.

## Validation

- `Invoke-Build -Task Lint, Build, Test`
- 944 passed, 0 failed, 19 skipped
- independent review: no concrete findings

## Related

- AtlassianPS/.github#3
