### PR TITLE
Centralize Standards updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "AtlassianPS/AtlassianPS.Standards*"
     labels:
       - dependencies
       - github_actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   module-ci:
-    uses: AtlassianPS/AtlassianPS.Standards/.github/workflows/module_ci.yml@8a75c583308d27526f29d7aaef1d1ba67c059103 # v0.3.0
+    uses: AtlassianPS/AtlassianPS.Standards/.github/workflows/module_ci.yml@bd959dc3de7ee8426f89c31a62e0282e7140bd51 # v0.3.4
 
   ci-required:
     name: CI Result

--- a/.github/workflows/continuous_release.yml
+++ b/.github/workflows/continuous_release.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   release:
-    uses: AtlassianPS/AtlassianPS.Standards/.github/workflows/module_release.yml@8a75c583308d27526f29d7aaef1d1ba67c059103 # v0.3.0
+    uses: AtlassianPS/AtlassianPS.Standards/.github/workflows/module_release.yml@bd959dc3de7ee8426f89c31a62e0282e7140bd51 # v0.3.4
     with:
       module-name: AtlassianPS.Configuration
       release-impact: ${{ inputs.release_impact }}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@8a75c583308d27526f29d7aaef1d1ba67c059103 # v0.3.0
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@bd959dc3de7ee8426f89c31a62e0282e7140bd51 # v0.3.4

--- a/.github/workflows/release_intent.yml
+++ b/.github/workflows/release_intent.yml
@@ -13,4 +13,4 @@ jobs:
     name: Release Intent
     runs-on: ubuntu-latest
     steps:
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/validate-release-intent@8a75c583308d27526f29d7aaef1d1ba67c059103 # v0.3.0
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/validate-release-intent@bd959dc3de7ee8426f89c31a62e0282e7140bd51 # v0.3.4

--- a/AtlassianPS.Configuration.build.ps1
+++ b/AtlassianPS.Configuration.build.ps1
@@ -1,5 +1,5 @@
 ﻿#requires -modules InvokeBuild
-#requires -modules @{ ModuleName = 'AtlassianPS.Standards'; ModuleVersion = '0.3.0'; MaximumVersion = '0.3.0' }
+#requires -modules @{ ModuleName = 'AtlassianPS.Standards'; ModuleVersion = '0.3.4'; MaximumVersion = '0.3.4' }
 
 [CmdletBinding()]
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingWriteHost', '')]

--- a/Tests/GitHubActions.Unit.Tests.ps1
+++ b/Tests/GitHubActions.Unit.Tests.ps1
@@ -72,5 +72,6 @@ Describe 'GitHub Actions release contract' -Tag Unit {
         $dependabot | Should -Match '(?m)^\s+- dependencies\r?$'
         $dependabot | Should -Match '(?m)^\s+- github_actions\r?$'
         $dependabot | Should -Match '(?m)^\s+- "release:none"\r?$'
+        $dependabot | Should -Match 'ignore:[\s\S]+dependency-name:\s*"AtlassianPS/AtlassianPS\.Standards\*"'
     }
 }

--- a/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
+++ b/Tests/Tools/StandardsVersionConsistency.Unit.Tests.ps1
@@ -4,7 +4,7 @@ Describe 'AtlassianPS.Standards version consistency' -Tag Unit {
     BeforeAll {
         . "$PSScriptRoot/../Helpers/TestTools.ps1"
         $script:projectRoot = Resolve-ProjectRoot
-        $script:standardsActionSha = '8a75c583308d27526f29d7aaef1d1ba67c059103'
+        $script:standardsActionSha = 'bd959dc3de7ee8426f89c31a62e0282e7140bd51'
 
         $requirementsPath = Join-Path $script:projectRoot 'Tools/build.requirements.psd1'
         $requirements = Import-PowerShellDataFile -Path $requirementsPath

--- a/Tools/build.requirements.psd1
+++ b/Tools/build.requirements.psd1
@@ -1,5 +1,5 @@
 ﻿@(
-    @{ ModuleName = "AtlassianPS.Standards"; RequiredVersion = "0.3.0" }
+    @{ ModuleName = "AtlassianPS.Standards"; RequiredVersion = "0.3.4" }
     @{ ModuleName = "InvokeBuild"; RequiredVersion = "5.14.23" }
     @{ ModuleName = "Metadata"; RequiredVersion = "1.5.7" }
     @{ ModuleName = "Configuration"; RequiredVersion = "1.6.0" }


### PR DESCRIPTION
## Summary

- update the Standards module and all shared workflow pins atomically to v0.3.4
- keep third-party GitHub Actions under Dependabot
- reserve Standards updates for the organization controller so module versions and action SHAs cannot drift

## Validation

- actionlint
- Invoke-Build -Task Lint, Build, Test
- 944 passed, 0 failed, 19 skipped
- focused post-rebase contract tests: 12 passed, 0 failed

## Related

- AtlassianPS/.github#3